### PR TITLE
Fix to make mintupdate run at startup for MATE session.

### DIFF
--- a/etc/xdg/autostart/mintupdate.desktop
+++ b/etc/xdg/autostart/mintupdate.desktop
@@ -7,5 +7,5 @@ Exec=mintupdate-launcher
 Terminal=false
 Type=Application
 Categories=
-OnlyShowIn=GNOME;XFCE;KDE;
+OnlyShowIn=GNOME;XFCE;KDE;MATE;
 


### PR DESCRIPTION
mintupdate was not being run at startup due to "MATE;" missing from "OnlyShowIn".

The issue was discussed here: http://forums.linuxmint.com/viewtopic.php?f=206&t=89397
