### PR TITLE
Change Update history window from 'center-always' to 'center'.

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.glade
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.glade
@@ -2210,7 +2210,7 @@ Public License instead of this License.
     <property name="visible">True</property>
     <property name="title" translatable="yes" context="yes">mintUpdate</property>
     <property name="modal">True</property>
-    <property name="window_position">center-always</property>
+    <property name="window_position">center</property>
     <property name="icon">/usr/lib/linuxmint/mintUpdate/icons/icon.png</property>
     <child>
       <widget class="GtkVBox" id="vbox3">


### PR DESCRIPTION
This fix is identical to the recent patch for the Information dialog. The same issue is preset in the Update History view, as well. Also see Launchpad Bug #1093304.

Thanks,
Geoff
