### PR TITLE
Also check for name:arch in the selected packages

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/checkWarnings.py
+++ b/usr/lib/linuxmint/mintUpdate/checkWarnings.py
@@ -42,8 +42,9 @@ try:
             if not depcache.marked_keep(pkg):
                if depcache.marked_install(pkg) or depcache.marked_upgrade(pkg):
                   if not pkg.Name in selection:
-                    if not pkg in packages_to_install:
-                      packages_to_install.append(pkg)
+                    if not '%s:%s' % (pkg.Name, pkg.Arch) in selection:
+                      if not pkg in packages_to_install:
+                        packages_to_install.append(pkg)
             if depcache.marked_delete(pkg):
                   if not pkg in packages_to_remove:
                       packages_to_remove.append(pkg)                   


### PR DESCRIPTION
This fixes mintupdate telling you that it's installing a package, when it is in fact upgrading the :i386 version of the package on 64-bit systems. (Happens frequently with steam for example, which is i386 and often upgraded: mintupdate told that it's installing steam, when it upgraded steam:i386)

Also, Geany automatically added a newline at the end of your file.
