### PR TITLE
Tweak the width of the information window

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.glade
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.glade
@@ -2194,7 +2194,7 @@ Public License instead of this License.
                 <property name="shadow_type">etched-in</property>
                 <child>
                   <widget class="GtkTextView" id="log_textview">
-                    <property name="width_request">437</property>
+                    <property name="width_request">600</property>
                     <property name="height_request">248</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>


### PR DESCRIPTION
Information window widened a little, so that it should not have to be stretched sideways to see the contents in most cases.
