### PR TITLE
Alter history of updates window sizing

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.glade
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.glade
@@ -2249,6 +2249,8 @@ Public License instead of this License.
   </widget>
   <widget class="GtkWindow" id="window4">
     <property name="height_request">400</property>
+    <property name="default_width">1000</property>
+    <property name="default_height">500</property>
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="title" translatable="yes" context="yes">mintUpdate</property>
@@ -2257,7 +2259,7 @@ Public License instead of this License.
     <property name="icon">/usr/lib/linuxmint/mintUpdate/icons/icon.png</property>
     <child>
       <widget class="GtkVBox" id="vbox3">
-        <property name="width_request">600</property>
+        <property name="width_request">475</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="border_width">5</property>


### PR DESCRIPTION
Default size set so that it opens with a size that looks about right (to me) in relation to the main window.  Set the minimum width so that it can be trimmed down to show just date and package, and the height can be reduced a little too if required.
