### PR TITLE
Fixed LibreOffice placing at level 2 (didn't work as expected)

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/rules
+++ b/usr/lib/linuxmint/mintUpdate/rules
@@ -5,7 +5,7 @@ thunderbird|*|2||
 *flashplugin|*|2||
 *wine|*|2||
 pidgin|*|2||
-libreoffice*|*|2||
+*libreoffice|*|2||
 chromium-browser|*|2||
 dbus|*|4||
 *xorg|*|4||


### PR DESCRIPTION
The last change made all LibreOffice packages to show up at level 3 instead of 2. Don't know why, but moving the wildcard to the beginning of the line fixed that.
