### PR TITLE
Don't crash with glib >= 2.41

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -2170,7 +2170,10 @@ try:
 
     auto_refresh = AutomaticRefreshThread(treeview_update, statusIcon, wTree)
     auto_refresh.start()
+    
+    gtk.gdk.threads_enter()
     gtk.main()
+    gtk.gdk.threads_leave()
 
 except Exception, detail:
     print detail


### PR DESCRIPTION
fixes https://github.com/linuxmint/mintupdate/issues/86
fixes https://github.com/linuxmint/mintupdate/issues/88