### PR TITLE
override harmless image-file-in-usr-lib warnings

### DIFF
--- a/debian/lintian-overrides
+++ b/debian/lintian-overrides
@@ -1,0 +1,1 @@
+image-file-in-usr-lib


### PR DESCRIPTION
As an alternative, the directory `/usr/lib/linuxmint/mintUpdate/icons` could be moved to /usr/share and be replaced with a symbolic link.