### PR TITLE
fix usage of dh_python2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,8 @@ Source: mintupdate
 Section: admin
 Priority: optional
 Maintainer: Clement Lefebvre <root@linuxmint.com>
-Build-Depends: debhelper (>= 9), python
+Build-Depends: debhelper (>= 9),
+               python (>= 2.7~)
 Standards-Version: 3.9.5
 
 Package: mintupdate
@@ -10,8 +11,6 @@ Architecture: all
 Depends:
  ${python:Depends},
  ${misc:Depends},
- python (>= 2.4),
- python (<< 3),
  python-gtk2,
  python-glade2,
  python-configobj,

--- a/debian/rules
+++ b/debian/rules
@@ -2,3 +2,7 @@
 
 %:
 	dh ${@} --with python2
+
+override_dh_python2:
+	dh_python2 /usr/lib/linuxmint/mintUpdate
+


### PR DESCRIPTION
dh_python2 will now look explicitly in /usr/lib/linuxmint/mintUpdate.
`python (>= 2.4), python (<< 3),` can be removed from the dependencies because the correct python version will now be added with `${python:Depends}` which was previously unused.