### PR TITLE
Show changelog from PPA packages - issue #56

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -83,6 +83,8 @@ try:
                         update_origin = "ubuntu"
                     elif origin.origin == "Debian":
                         update_origin = "debian"
+                    elif "LP-PPA" in origin.origin:
+                        update_origin = origin.origin
                     if origin.origin == "Ubuntu" and '-security' in origin.archive:
                         update_type = "security"
                         break
@@ -98,8 +100,6 @@ try:
                             break
                         else:
                             update_type = "linuxmint"
-                    elif "LP-PPA" in origin.origin:
-                        update_origin = origin.origin
 
                 resultString = u"UPDATE###%s###%s###%s###%s###%s###%s###%s###%s###%s---EOL---" % (package, newVersion, oldVersion, size, sourcePackage, update_type, update_origin, short_description, description)
                 print resultString.encode('ascii', 'xmlcharrefreplace')

--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -83,7 +83,7 @@ try:
                         update_origin = "ubuntu"
                     elif origin.origin == "Debian":
                         update_origin = "debian"
-                    elif "LP-PPA" in origin.origin:
+                    elif origin.origin.startswith("LP-PPA"):
                         update_origin = origin.origin
                     if origin.origin == "Ubuntu" and '-security' in origin.archive:
                         update_type = "security"

--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -98,6 +98,8 @@ try:
                             break
                         else:
                             update_type = "linuxmint"
+                    elif "LP-PPA" in origin.origin:
+                        update_origin = origin.origin
 
                 resultString = u"UPDATE###%s###%s###%s###%s###%s###%s###%s###%s###%s---EOL---" % (package, newVersion, oldVersion, size, sourcePackage, update_type, update_origin, short_description, description)
                 print resultString.encode('ascii', 'xmlcharrefreplace')

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -14,8 +14,8 @@ try:
     import time
     import gettext
     import fnmatch
+    import io
     import tarfile
-    import urllib
     import urllib2
     import re
     from sets import Set
@@ -156,44 +156,56 @@ class ChangelogRetriever(threading.Thread):
 
     def get_ppa_changelog(self, ppa_owner, ppa_name):
             max_tarball_size = 1000000
-            deb_changelog = ""
-            if (self.source_package.startswith("lib")):
+            print "\nFetching changelog for PPA package %s/%s/%s ..." % (ppa_owner, ppa_name, self.source_package)
+            if self.source_package.startswith("lib"):
                 ppa_abbr = self.source_package[:4]
             else:
-                ppa_abbr = self.source_package[:1]
+                ppa_abbr = self.source_package[0]
             deb_dsc_uri = "http://ppa.launchpad.net/%s/%s/ubuntu/pool/main/%s/%s/%s_%s.dsc" % (ppa_owner, ppa_name, ppa_abbr, self.source_package, self.source_package, self.version)
             try:
-                for line in urllib2.urlopen(deb_dsc_uri).readlines():
-                    if not "debian.tar" in line:
-                        continue
-                    line = line.strip()
-                    deb_checksum, deb_size, deb_filename = line.split(" ", 2)
-                    if (int(deb_size) > max_tarball_size):
-                        print "Tarball size %s exceeds maximum download size %s. Skipping download." % ( deb_size, str(max_tarball_size) )
-                        return None
-                    else:
-                        deb_file_uri = "http://ppa.launchpad.net/%s/%s/ubuntu/pool/main/%s/%s/%s" % (ppa_owner, ppa_name, ppa_abbr, self.source_package, deb_filename)
-                        print "Trying to fetch the changelog from: %s" % deb_file_uri
-                        tmp_file, tmp_headers = urllib.urlretrieve(deb_file_uri)
-                        if deb_filename.endswith(".xz"):
-                            cmd = ["xz", "--decompress", "%s" % tmp_file]
-                            subprocess.call(cmd, stdout=log, stderr=log)
-                            tmp_file = tmp_file[:-3]
-                        with tarfile.open(tmp_file) as f:
-                            deb_changelog = f.extractfile('debian/changelog').read()
-                        os.remove(tmp_file)
-                        return deb_changelog
-                return None
+                deb_dsc = urllib2.urlopen(deb_dsc_uri).readlines()
             except urllib2.URLError, e:
-                print "Could not open Launchpad URL"
-                print "Error message: %s" % e
-                return None
-            except OSError, e:
-                print "OS Error: %s" % e
-                return None
-            except Exception, detail:
-                print "Exception: %s" % detail
-                return None
+                print "Could not open Launchpad URL %s - %s" % (deb_dsc_uri, e)
+                return
+            for line in deb_dsc:
+                if "debian.tar" not in line:
+                    continue
+                deb_checksum, deb_size, deb_filename = line.strip().split(" ", 2)
+                break
+            else:
+                deb_filename = None
+            if not deb_filename or not deb_size or not deb_size.isdigit():
+                print "Unsupported debian .dsc file format. Skipping this package."
+                return
+            if (int(deb_size) > max_tarball_size):
+                print "Tarball size %s B exceeds maximum download size %d B. Skipping download." % (deb_size, max_tarball_size)
+                return
+            deb_file_uri = "http://ppa.launchpad.net/%s/%s/ubuntu/pool/main/%s/%s/%s" % (ppa_owner, ppa_name, ppa_abbr, self.source_package, deb_filename)
+            try:
+                deb_file = urllib2.urlopen(deb_file_uri).read()
+            except urllib2.URLError, e:
+                print "Could not download tarball from %s - %s" % (deb_file_uri, e)
+                return
+            if deb_filename.endswith(".xz"):
+                cmd = ["xz", "--decompress"]
+                try:
+                    xz = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+                    xz.stdin.write(deb_file)
+                    xz.stdin.close()
+                    deb_file = xz.stdout.read()
+                    xz.stdout.close()
+                except EnvironmentError, e:
+                    print "Error encountered while decompressing xz file: %s" % e
+                    return
+            deb_file = io.BytesIO(deb_file)
+            try:
+                with tarfile.open(fileobj = deb_file) as f:
+                    deb_changelog = f.extractfile("debian/changelog").read()
+            except tarfile.TarError, e:
+                print "Error encountered while reading tarball: %s" % e
+                return
+
+            return deb_changelog
 
     def run(self):
         gtk.gdk.threads_enter()
@@ -272,7 +284,6 @@ class ChangelogRetriever(threading.Thread):
                         if change == "" or stripped_change.startswith("*") or stripped_change.startswith("["):
                             changelog = changelog + change + "\n"
                 elif "launchpad.net" in changelog_source:
-                    print "Latest changelog entry has been scraped from Launchpad's source.changes file"
                     lpchange = source.split("Changes:")[1].split("Checksums")[0]
                     changelog = "--- PPA Changelog Latest Entry ---\n%s\n" % lpchange
                 else:

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -216,6 +216,44 @@ class ChangelogRetriever(threading.Thread):
             except:
                 pass
 
+        # If changelog retrieval was not successful from official sources, check for a PPA changelog entry on Launchpad
+        if changelog == "No changelog available":
+            try:
+
+                ppapackage 	= self.source_package
+                ppaversion 	= self.version              
+
+                # Get PPA owner and name (Method 1 - Only works with installed packages)
+                # output    = subprocess.check_output("apt-cache policy %s | grep launchpad" % ppapackage, shell = True)
+                # ppainfo   = output.split("http://ppa.launchpad.net/",1)[1]
+                # ppawords  = ppainfo.split("/")
+                # ppaowner  = ppawords[0]
+                # ppaname   = ppawords[1]
+
+                # Get PPA owner and name (Method 2 - Works for both installed and yet to be installed packages)
+                cmd         = "grep %s /var/lib/apt/lists/ppa* --no-messages | grep %s" % (ppapackage, ppaversion)
+                output      = subprocess.check_output(cmd, shell = True)
+                ppainfo     = output.split("ppa.launchpad.net_", 1)[1]
+                ppawords    = ppainfo.split("_", 2)
+                ppaowner    = ppawords[0]
+                ppaname     = ppawords[1]
+
+                # Build the URL for the PPA changes file and download it
+                lpurl       = "https://launchpad.net/~%s/+archive/ubuntu/%s/+files/%s_%s_source.changes" % (ppaowner, ppaname, ppapackage, ppaversion)
+                print       "Changelog not found in offical sources. Attempting to fetch PPA changelog from %s" % lpurl
+                lpfile      = urllib2.urlopen(lpurl)
+                lpcontents  = lpfile.read()
+                lpfile.close()
+
+                # Extract only the change information
+                lpchange    = lpcontents.split("Changes:")[1].split("Checksums")[0]
+
+                # Set the changelog variable
+                changelog   = "--- PPA Changelog Latest Entry ---\n%s\n" % lpchange
+
+            except:
+                pass
+
         gtk.gdk.threads_enter()
         self.wTree.get_widget("textview_changes").get_buffer().set_text(changelog)
         gtk.gdk.threads_leave()

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -182,11 +182,14 @@ class ChangelogRetriever(threading.Thread):
                 changelog_sources.append("http://metadata.ftp-master.debian.org/changelogs/contrib/%s/%s/%s_%s_changelog" % (self.source_package[0], self.source_package, self.source_package, self.version))
                 changelog_sources.append("http://metadata.ftp-master.debian.org/changelogs/non-free/%s/%s/%s_%s_changelog" % (self.source_package[0], self.source_package, self.source_package, self.version))
         elif "LP-PPA" in self.origin:
-                cmd         = "more /etc/apt/sources.list.d/%s*" % self.origin.split("LP-PPA-")[1]
-                output      = subprocess.check_output(cmd, stderr=log, shell=True)          
-                ppainfo     = output.split("ppa.launchpad.net/")[1]
-                ppawords    = ppainfo.split("/", 2)
-                changelog_sources.append("https://launchpad.net/~%s/+archive/ubuntu/%s/+files/%s_%s_source.changes" % (ppawords[0], ppawords[1], self.source_package, self.version)) 
+            ppa_sources = "/etc/apt/sources.list.d/"
+            for fn in os.listdir(ppa_sources):
+                if fnmatch.fnmatch(fn, "%s*" % self.origin.split("LP-PPA-")[1]):
+                    with open(os.path.join(ppa_sources, fn), 'r') as f:
+                        ppa_info = f.read().split("ppa.launchpad.net/")[1]
+                        ppa_owner, ppa_name, ppa_distro = ppa_info.split("/", 2)
+                        changelog_sources.append("https://launchpad.net/~%s/+archive/ubuntu/%s/+files/%s_%s_source.changes" % (ppa_owner, ppa_name, self.source_package, self.version))
+                    break
 
         changelog = _("No changelog available")
 

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -182,13 +182,11 @@ class ChangelogRetriever(threading.Thread):
                 changelog_sources.append("http://metadata.ftp-master.debian.org/changelogs/contrib/%s/%s/%s_%s_changelog" % (self.source_package[0], self.source_package, self.source_package, self.version))
                 changelog_sources.append("http://metadata.ftp-master.debian.org/changelogs/non-free/%s/%s/%s_%s_changelog" % (self.source_package[0], self.source_package, self.source_package, self.version))
         elif "LP-PPA" in self.origin:
-                cmd         = "grep %s /var/lib/apt/lists/ppa* --no-messages | grep %s" % (self.source_package, self.version)
-                output      = subprocess.check_output(cmd, shell=True)
-                ppainfo     = output.split("ppa.launchpad.net_", 1)[1]
-                ppawords    = ppainfo.split("_", 2)
-                ppaowner    = ppawords[0]
-                ppaname     = ppawords[1]
-                changelog_sources.append("https://launchpad.net/~%s/+archive/ubuntu/%s/+files/%s_%s_source.changes" % (ppaowner, ppaname, self.source_package, self.version)) 
+                cmd         = "more /etc/apt/sources.list.d/%s*" % self.origin.split("LP-PPA-")[1]
+                output      = subprocess.check_output(cmd, stderr=log, shell=True)          
+                ppainfo     = output.split("ppa.launchpad.net/")[1]
+                ppawords    = ppainfo.split("/", 2)
+                changelog_sources.append("https://launchpad.net/~%s/+archive/ubuntu/%s/+files/%s_%s_source.changes" % (ppawords[0], ppawords[1], self.source_package, self.version)) 
 
         changelog = _("No changelog available")
 


### PR DESCRIPTION
Hi :)

This is my attempt to display the latest changelog entry for PPA packages. 

If a changelog is not found in the official sources, the code assumes the package comes from a PPA and tries to get the latest changelog entry from Launchpad. 

I have tried using two different methods to get the PPA owner and name, which are required to build the Launchpad URL. The first method, which I've commented out, will throw an exception when issuing the apt-cache command if the package has not been installed. I think the second method is better, but please let me know if there is an easier or more efficient way of doing this. I've tested it successfully with four different Launchpad hosted PPAs. 

This is my first attempt to contribute to the Linux Mint codebase and I am relatively new to Python (and git/Github), so please let me know if you have any feedback...