### PR TITLE
main.ui: Add a primary-toolbar style class to the main toolbar. Gives…

### DIFF
--- a/usr/share/linuxmint/mintupdate/main.ui
+++ b/usr/share/linuxmint/mintupdate/main.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.16.1 -->
 <interface>
-  <requires lib="gtk+" version="2.24"/>
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="main_window">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">mintUpdate</property>
@@ -60,6 +60,7 @@
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="homogeneous">False</property>
                   </packing>
                 </child>
                 <child>
@@ -80,6 +81,7 @@
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="homogeneous">False</property>
                   </packing>
                 </child>
                 <child>
@@ -94,6 +96,9 @@
                     <property name="homogeneous">True</property>
                   </packing>
                 </child>
+                <style>
+                  <class name="primary-toolbar"/>
+                </style>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -131,8 +136,6 @@
                       <object class="GtkScrolledWindow" id="scrolledwindow2">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="hscrollbar_policy">automatic</property>
-                        <property name="vscrollbar_policy">automatic</property>
                         <property name="shadow_type">in</property>
                         <child>
                           <object class="GtkTreeView" id="treeview_update">
@@ -143,6 +146,9 @@
                             <property name="enable_search">False</property>
                             <signal name="cursor-changed" handler="on_treeview_update_cursor_changed" swapped="no"/>
                             <signal name="row-activated" handler="on_treeview_update_row_activated" swapped="no"/>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection" id="treeview-selection1"/>
+                            </child>
                           </object>
                         </child>
                       </object>
@@ -161,8 +167,6 @@
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="border_width">6</property>
-                            <property name="hscrollbar_policy">automatic</property>
-                            <property name="vscrollbar_policy">automatic</property>
                             <property name="shadow_type">in</property>
                             <child>
                               <object class="GtkTextView" id="textview_description">
@@ -199,8 +203,6 @@
                               <object class="GtkScrolledWindow" id="scrolledwindow_changes">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="hscrollbar_policy">automatic</property>
-                                <property name="vscrollbar_policy">automatic</property>
                                 <property name="shadow_type">in</property>
                                 <child>
                                   <object class="GtkTextView" id="textview_changes">
@@ -350,8 +352,6 @@
                   <object class="GtkScrolledWindow" id="scrolledwindow1">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="hscrollbar_policy">automatic</property>
-                    <property name="vscrollbar_policy">automatic</property>
                     <property name="shadow_type">out</property>
                     <child>
                       <object class="GtkViewport" id="viewport1">


### PR DESCRIPTION
… it a proper toolbar appearance and brings back the toolbar separators