### PR TITLE
mintUpdate.py: don't download changelog each time on tab switch

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -1787,31 +1787,29 @@ class MintUpdate():
             (model, iter) = selection.get_selected()
             if (iter != None):
                 package_update = model.get_value(iter, UPDATE_OBJ)
+                self.display_package_description(package_update)
                 if self.builder.get_object("notebook_details").get_current_page() == 0:
                     # Description tab
-                    self.display_package_description(package_update)
+                    self.changelog_retriever_started = False
                 else:
                     # Changelog tab
                     retriever = ChangelogRetriever(package_update, self)
                     retriever.start()
+                    self.changelog_retriever_started = True
         except Exception as e:
             print (e)
             print(sys.exc_info()[0])
 
     def switch_page(self, notebook, page, page_num):
-        self.builder.get_object("textview_description").get_buffer().set_text("")
-        self.builder.get_object("textview_changes").get_buffer().set_text("")
         selection = self.treeview.get_selection()
         (model, iter) = selection.get_selected()
         if (iter != None):
-            package_update = model.get_value(iter, UPDATE_OBJ)
-            if (page_num == 0):
-                # Description tab
-                self.display_package_description(package_update)
-            else:
+            if (page_num == 1 and not self.changelog_retriever_started):
                 # Changelog tab
+                package_update = model.get_value(iter, UPDATE_OBJ)
                 retriever = ChangelogRetriever(package_update, self)
                 retriever.start()
+                self.changelog_retriever_started = True
 
     def display_package_description(self, package_update):
         description = package_update.description


### PR DESCRIPTION
Fixes #26

While viewing the same package, each time a switch was done from the Description to the Changelog tab the changelogs would be downloaded anew.

The function switch_page is called when switching between tabs while viewing the same package. This function is changed to not erase the contents of the Description and Changelog tabs. The changelogs will only be downloaded if the Changelog tab is being switched to and haven't been downloaded yet while viewing this package.

The function display_selected_package is called when selected another package to view. This function is changed to always set the Description tab.