### PR TITLE
mintUpdate.py: show version number in About Dialog

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -1975,6 +1975,13 @@ class MintUpdate():
             print (e)
             print(sys.exc_info()[0])
 
+        try:
+            version = subprocess.getoutput("/usr/lib/linuxmint/common/version.py mintupdate")
+            dlg.set_version(version)
+        except Exception as e:
+            print (e)
+            print(sys.exc_info()[0])
+
         dlg.set_icon_name("mintupdate")
         dlg.set_logo_icon_name("mintupdate")
         dlg.set_website("http://www.github.com/linuxmint/mintupdate")


### PR DESCRIPTION
Fixes #171. Restores, and adapts to Python 3, the lines from mintupdate version 4.9.9.1 to show the version number in the About Dialog.