### PR TITLE
Fixed label padding in "additional changes" dialog

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -420,6 +420,7 @@ class InstallThread(threading.Thread):
                                     else:
                                         label.set_text(_("The following %d packages will be removed:") % len(removals))
                                     label.set_alignment(0, 0.5)
+                                    label.set_padding(20, 0)
                                     scrolledWindow = Gtk.ScrolledWindow()
                                     scrolledWindow.set_shadow_type(Gtk.ShadowType.IN)
                                     scrolledWindow.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
@@ -451,6 +452,7 @@ class InstallThread(threading.Thread):
                                     else:
                                         label.set_text(_("The following %d packages will be installed:") % len(installations))
                                     label.set_alignment(0, 0.5)
+                                    label.set_padding(20, 0)
                                     scrolledWindow = Gtk.ScrolledWindow()
                                     scrolledWindow.set_shadow_type(Gtk.ShadowType.IN)
                                     scrolledWindow.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)


### PR DESCRIPTION
Before there was no padding and the label _The following package will be installed_ was positioned right at the left edge of the window:

![mintupdate-no-padding](https://cloud.githubusercontent.com/assets/24710687/21457989/1c4ee33e-c92b-11e6-8cdc-60c8613f41f5.png)

Simply increasing the x value of `set_alignment` doesn't work nicely because there's still no padding at the right edge, while `set_padding` does just what is needed. A value of 20 pixels was picked as appropriate after trying just 5, 10, 15, 20, and 25 pixels, so someone might improve this further. Here's the result:

![mintupdate-padding-20](https://cloud.githubusercontent.com/assets/24710687/21458622/f93c8e32-c92f-11e6-960d-b2d6da65aac7.png)


