### PR TITLE
Fixes grouping of kernel updates

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -128,6 +128,13 @@ class APTCheck():
 
         source_name = package.candidate.source_name
 
+        # added by Sven Kochmann, March 2017
+        # Source name is ok, unless it is about kernels... then source_name will be just 'linux' or 'linux-hwe'
+        # Therefore, we use the package.name for sorting/grouping now; this here groups the "real" kernel-update together,
+        # i.e. does not accidently group together the libc-dev update from 4.4 and the image from 4.8...
+        if kernel_update and (package.name.startswith("linux-image") or package.name.startswith("linux-headers")):
+                source_name = package.name.replace("-generic", "").replace("-extra", "").replace("-headers", "").replace("-image", "")
+
         # ignore blacklisted packages
         for blacklist in self.settings.get_strv("blacklisted-packages"):
             if fnmatch.fnmatch(source_name, blacklist):

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -695,9 +695,9 @@ class RefreshThread(threading.Thread):
                             if len(shortdesc) > 100:
                                 shortdesc = shortdesc[:100] + "..."
                             if (self.application.settings.get_boolean("show-descriptions")):
-                                model.set_value(iter, UPDATE_DISPLAY_NAME, update.display_name + "\n<i><small><span foreground='%s'>%s</span></small></i>" % (insensitive_color, shortdesc))
+                                model.set_value(iter, UPDATE_DISPLAY_NAME, update.display_name + " (" + update.main_package_name + ")" + "\n<i><small><span foreground='%s'>%s</span></small></i>" % (insensitive_color, shortdesc))
                             else:
-                                model.set_value(iter, UPDATE_DISPLAY_NAME, update.display_name)
+                                model.set_value(iter, UPDATE_DISPLAY_NAME, update.display_name + " (" + update.main_package_name + ")")
 
                             theme = Gtk.IconTheme.get_default()
                             pixbuf = theme.load_icon("mintupdate-level" + str(update.level), 22, 0)


### PR DESCRIPTION
This refers to issues #219, #108, and others.

I discovered the following problem in add_update of checkAPT.py: the original idea was (I think) to group updates together, so that the user only has to check one package for one application. Grouping is done by using the source_name attribute of a cached update.

This works fine for normal applications. However, for all kernel-related stuff, source_name is always "linux" or similar. It does not matter, if the update is actually a 4.4-libc-dev package, the actual source of a kernel, or the kernel image/extra packages.

Together with the "aliases"-functions this leads to the very funny following situation on my computer (and others):
- packages: 4.4-libc-dev, 4.8-image, 4.8-image-extra, 4.8-headers, 4.8-hwe are successfully evaluated by find_changes
- since all there source_names are identical ('linux'), they are grouped together
- the 4.4-libc-dev update is "first" and defines therefore the name chosen by the aliases-functions: Linux Kernel 4.4.x.y (although I am running on 4.8 right now)

Confusion for everyone!

So, this PR proposes _two_ changes. One in checkAPT.py uses package.name as base for the source_name _if_ the package to add is a kernel thing. To facilitate bug reports a little bit, I also added the main_package_name for displaying in brackets after the source_name (see screenshot below). If this would be visible, I am sure someone else would have figured out.

As you can see there is still a little thing to add/fix: for the kernel 4.8 update listed there is no "old_version" displayed. Maybe someone can look on this when auditing my PR - wanted to get it out, because Jeremy asked in #linuxmint-dev :)

![bildschirmfoto zu 2017-03-17_00-06-10](https://cloud.githubusercontent.com/assets/6428497/24028939/5e2d7d00-0aa9-11e7-8288-d1d42a7769d2.png)
