### PR TITLE
reduce min height to fit window into 800x600 screen

### DIFF
--- a/usr/share/linuxmint/mintupdate/main.ui
+++ b/usr/share/linuxmint/mintupdate/main.ui
@@ -82,7 +82,7 @@
         <property name="can_focus">True</property>
         <property name="hexpand">True</property>
         <property name="vexpand">True</property>
-        <property name="min_content_height">360</property>
+        <property name="min_content_height">200</property>
         <child>
           <object class="GtkViewport" id="viewport2">
             <property name="visible">True</property>


### PR DESCRIPTION
Looking at [release announcement of Linux Mint 18.2 Xfce Beta](http://blog.linuxmint.com/?p=3281) it says in the system requirements:
> Graphics card capable of 800×600 resolution

But the mintupdate window doesn't fit into a screen with 800x600 resolution, makes it even barely impossible for users to use mintupdate, because the "Help" and "Apply" buttons in the policy window, which appears the very first time after installation, are not visible. Only solution for those users is to use "Alt + Drag", and not every user knows about this workaround.

Changing the min_content_height to 200 fixes this problem. This makes the mintupdate window fit completely into a 800x600 screen.

Fixes https://github.com/linuxmint/mintupdate/issues/170