### PR TITLE
Use the correct icon in the autostart desktop file

### DIFF
--- a/etc/xdg/autostart/mintupdate.desktop
+++ b/etc/xdg/autostart/mintupdate.desktop
@@ -2,7 +2,7 @@
 Encoding=UTF-8
 Name=mintUpdate
 Comment=Linux Mint Update Manager
-Icon=stock_lock
+Icon=mintupdate
 Exec=mintupdate-launcher
 Terminal=false
 Type=Application


### PR DESCRIPTION
Cinnamon settings, for example, was showing the wrong icon in the startup applications module.