### PR TITLE
Update mintUpdate.py

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -465,7 +465,7 @@ class InstallThread(threading.Thread):
 
                             command = "/usr/lib/linuxmint/mintUpdate/mintUpdate.py show &"
                             os.system(command)
-                        
+
                         # Refresh
                         Gdk.threads_enter()
                         self.application.set_status(_("Checking for updates"), _("Checking for updates"), "mintupdate-checking", not self.application.settings.get_boolean("hide-systray"))


### PR DESCRIPTION
Only restart mintupdate for updates to "mintupdate" or "mint-upgrade-info" if installing them was successful.
If installation was cancelled by the user or failed, no need to restart mintupdate.
See issue #214