### PR TITLE
fix: end process mintupdate-launcher after run mintUpdate

### DIFF
--- a/usr/bin/mintupdate-launcher
+++ b/usr/bin/mintupdate-launcher
@@ -4,4 +4,4 @@ import os
 import xapp.os
 
 if ((not xapp.os.is_live_session()) and (not xapp.os.is_guest_session())):
-	os.system("/usr/lib/linuxmint/mintUpdate/mintUpdate.py")
+	os.system("/usr/lib/linuxmint/mintUpdate/mintUpdate.py &")


### PR DESCRIPTION
We do not need `mintupdate-launcher` (that awaits `mintUpdate.py`) in memory, right?