### PR TITLE
ui: Use new GtkTextView settings to provide top and bottom margins

### DIFF
--- a/usr/share/linuxmint/mintupdate/main.ui
+++ b/usr/share/linuxmint/mintupdate/main.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.4 -->
+<!-- Generated with glade 3.22.0 -->
 <interface>
-  <requires lib="gtk+" version="3.10"/>
+  <requires lib="gtk+" version="3.20"/>
   <object class="GtkBox" id="configure_page">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -863,12 +863,12 @@
                   <object class="GtkTextView" id="textview_description">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="margin_top">6</property>
-                    <property name="margin_bottom">6</property>
                     <property name="editable">False</property>
                     <property name="wrap_mode">word</property>
                     <property name="left_margin">6</property>
                     <property name="right_margin">6</property>
+                    <property name="top_margin">6</property>
+                    <property name="bottom_margin">6</property>
                     <property name="cursor_visible">False</property>
                     <property name="accepts_tab">False</property>
                   </object>
@@ -894,11 +894,11 @@
                   <object class="GtkTextView" id="textview_changes">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="margin_top">6</property>
-                    <property name="margin_bottom">6</property>
                     <property name="editable">False</property>
                     <property name="left_margin">6</property>
                     <property name="right_margin">6</property>
+                    <property name="top_margin">6</property>
+                    <property name="bottom_margin">6</property>
                     <property name="cursor_visible">False</property>
                   </object>
                 </child>


### PR DESCRIPTION
This prevents the need for theme workarounds to prevent a slightly different
colored strip along the top and bottom of the description and changelog tabs.