### PR TITLE
checkAPT: generate a new mintinstall cache after updating our apt cache

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -331,6 +331,9 @@ if __name__ == "__main__":
         check.apply_aliases()
         check.clean_descriptions()
         check.serialize_updates()
+        if os.path.exists("/usr/bin/mintinstall-update-pkgcache"):
+            import subprocess
+            subprocess.run(['/usr/bin/mintinstall-update-pkgcache'], timeout=60)
     except Exception as error:
         print("CHECK_APT_ERROR---EOL---")
         print(sys.exc_info()[0])


### PR DESCRIPTION
I'm a bit on the fence whether this should hold up checkAPT or not from exiting.

I considered only updating when there's no mintUpdate window (background updates?) but skipping when it's from the user having clicked "Refresh" (moving it to APTCheck.refresh_cache would make the most sense then.)