### PR TITLE
kernel window: support new linux-modules-* packages

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -33,7 +33,7 @@ class InstallKernelThread(threading.Thread):
                 "--non-interactive", "--parent-window-id", "%s" % self.application.window.get_window().get_xid(), "-o", "Synaptic::closeZvt=true"]
         f = tempfile.NamedTemporaryFile()
 
-        for pkg in ['linux-headers-%s' % self.version, 'linux-headers-%s-generic' % self.version, 'linux-image-%s-generic' % self.version, 'linux-image-extra-%s-generic' % self.version]:
+        for pkg in ['linux-headers-%s' % self.version, 'linux-headers-%s-generic' % self.version, 'linux-image-%s-generic' % self.version, 'linux-modules-%s-generic' % self.version, 'linux-modules-extra-%s-generic' % self.version]:
             if self.remove:
                 pkg_line = "%s\tpurge\n" % pkg
             else:


### PR DESCRIPTION
`linux-image-extra-*` is no more in Ubuntu 18.04

`linux-modules-*` + `linux-modules-extra-*` replace it