### PR TITLE
using /usr/bin/env to locate python3 and replaced os with subprocess

### DIFF
--- a/usr/bin/mint-release-upgrade
+++ b/usr/bin/mint-release-upgrade
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
-import os
-os.system("/usr/lib/linuxmint/mintUpdate/rel_upgrade.py")
+import subprocess
+
+subprocess.Popen("/usr/lib/linuxmint/mintUpdate/rel_upgrade.py".strip(), shell=True)


### PR DESCRIPTION
Using env to locate python3 interpreter and replaced os.system with subprocess.Popen.

I'm being cautious and I'm only updating one file