### PR TITLE
show notification "updates available"

### DIFF
--- a/usr/share/glib-2.0/schemas/com.linuxmint.updates.gschema.xml
+++ b/usr/share/glib-2.0/schemas/com.linuxmint.updates.gschema.xml
@@ -191,5 +191,10 @@
       <summary></summary>
       <description></description>
     </key>
+    <key type="b" name="show-notification">
+      <default>false</default>
+      <summary></summary>
+      <description></description>
+    </key>
   </schema>
 </schemalist>

--- a/usr/share/linuxmint/mintupdate/preferences.ui
+++ b/usr/share/linuxmint/mintupdate/preferences.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkAdjustment" id="adjustment1">
@@ -145,7 +145,9 @@
     <property name="window_position">center</property>
     <property name="default_width">750</property>
     <property name="default_height">400</property>
-    <property name="gravity">center</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="box1">
         <property name="visible">True</property>
@@ -250,9 +252,6 @@
           </packing>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
   <object class="GtkBox" id="page_auto">

--- a/usr/share/linuxmint/mintupdate/preferences.ui
+++ b/usr/share/linuxmint/mintupdate/preferences.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkAdjustment" id="adjustment1">
@@ -145,9 +145,7 @@
     <property name="window_position">center</property>
     <property name="default_width">750</property>
     <property name="default_height">400</property>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
+    <property name="gravity">center</property>
     <child>
       <object class="GtkBox" id="box1">
         <property name="visible">True</property>
@@ -252,6 +250,9 @@
           </packing>
         </child>
       </object>
+    </child>
+    <child type="titlebar">
+      <placeholder/>
     </child>
   </object>
   <object class="GtkBox" id="page_auto">
@@ -878,6 +879,22 @@
               </packing>
             </child>
             <child>
+              <object class="GtkCheckButton" id="checkbutton_show_notification">
+                <property name="label" translatable="no">Notify about updates available</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="margin_left">24</property>
+                <property name="xalign">0</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">5</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
@@ -892,7 +909,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">5</property>
+                <property name="position">6</property>
               </packing>
             </child>
             <child>
@@ -908,7 +925,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">6</property>
+                <property name="position">7</property>
               </packing>
             </child>
             <child>
@@ -924,7 +941,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">7</property>
+                <property name="position">8</property>
               </packing>
             </child>
             <child>
@@ -940,7 +957,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">8</property>
+                <property name="position">9</property>
               </packing>
             </child>
             <child>
@@ -956,7 +973,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">9</property>
+                <property name="position">10</property>
               </packing>
             </child>
             <child>
@@ -972,7 +989,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">10</property>
+                <property name="position">11</property>
               </packing>
             </child>
             <child>
@@ -988,7 +1005,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">11</property>
+                <property name="position">12</property>
               </packing>
             </child>
           </object>


### PR DESCRIPTION
At the beginning of this year we had some discussion on a german forum why there is no notification about available updates. We made some shell scripts, but my opinion was it would be easier to integrate it in mintupdate itself. So I had some studies in python and tested the code on my machine.

If you dislike it, no matter. It was harder for me to create this pull request than making this little code. If you like it, of cause it needs translation. I think it would be nice to disable it by default so the user can figure it out by his own and old users would not be confused about something new.

https://www.linuxmintusers.de/index.php?topic=41404.msg666057#msg666057