### PR TITLE
Origin column: replace url with release pocket

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/Classes.py
+++ b/usr/lib/linuxmint/mintUpdate/Classes.py
@@ -57,12 +57,14 @@ class Update():
             self.display_name = self.source_name
             self.short_description = package.candidate.raw_description
             self.description = package.candidate.description
+            self.archive = ""
             if (self.new_version != self.old_version):
                 self.type = "package"
                 self.origin = ""
                 for origin in package.candidate.origins:
                     self.origin = origin.origin
                     self.site = origin.site
+                    self.archive = origin.archive
                     if origin.origin == "Ubuntu":
                         self.origin = "ubuntu"
                     elif origin.origin == "Debian":
@@ -116,10 +118,14 @@ class Update():
     def overwrite_main_package(self, pkg):
         self.description = pkg.candidate.description
         self.short_description = pkg.candidate.raw_description
-        self.main_package_name  = pkg.name
+        self.main_package_name = pkg.name
 
     def serialize(self):
-        output_string = u"###%d###%s###%s###%s###%s###%s###%s###%s###%s###%s###%s###%s###%s###%s---EOL---" % (self.level, self.display_name, self.source_name, self.real_source_name, self.main_package_name, ", ".join(self.package_names), self.new_version, self.old_version, self.size, self.type, self.origin, self.short_description, self.description, self.site)
+        output_string = u"###%d###%s###%s###%s###%s###%s###%s###%s###%s###%s###%s###%s###%s###%s###%s---EOL---" % \
+        (self.level, self.display_name, self.source_name, self.real_source_name,\
+         self.main_package_name, ", ".join(self.package_names), self.new_version,\
+         self.old_version, self.size, self.type, self.origin, \
+         self.short_description, self.description, self.site, self.archive)
         print(output_string.encode('ascii', 'xmlcharrefreplace'))
 
     def parse(self, input_string):
@@ -128,7 +134,10 @@ class Update():
         except:
             pass
         values = input_string.split("###")
-        nothing, level, self.display_name, self.source_name, self.real_source_name, self.main_package_name, package_names, self.new_version, self.old_version, size, self.type, self.origin, self.short_description, self.description, self.site = values
+        _, level, self.display_name, self.source_name, self.real_source_name,\
+            self.main_package_name, package_names, self.new_version,\
+            self.old_version, size, self.type, self.origin, self.short_description,\
+            self.description, self.site, self.archive = values
         self.level = int(level)
         self.size = int(size)
         for package_name in package_names.split(", "):

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -737,7 +737,7 @@ class RefreshThread(threading.Thread):
                             model.set_value(iter, UPDATE_LEVEL_PIX, pixbuf)
                             model.set_value(iter, UPDATE_OLD_VERSION, update.old_version)
                             model.set_value(iter, UPDATE_NEW_VERSION, update.new_version)
-                            model.set_value(iter, UPDATE_SOURCE, "%s (%s)" % (origin, update.site))
+                            model.set_value(iter, UPDATE_SOURCE, "%s / %s" % (origin, update.archive))
                             model.set_value(iter, UPDATE_LEVEL_STR, str(update.level))
                             model.set_value(iter, UPDATE_SIZE, update.size)
                             model.set_value(iter, UPDATE_SIZE_STR, size_to_string(update.size))


### PR DESCRIPTION
The Origin column currently shows `Repository Name (URL)`. This patch replaces the URL with the release pocket to the format `Repository Name / release-pocket` instead.

The release pocket is relevant information - to some extent you already display it via the icons, but there is no way to identify if updates come from the -proposed pocket, for example, which to me is relevant information. 

The URL, on the other hand, seems quite irrelevant to me and can be looked up in Software Sources, where required, so I decided to replace it rather than add the release pocket in addition to it.