### PR TITLE
Kernel window: Sort kernel series descending

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -260,7 +260,7 @@ class KernelWindow():
                 if page_label not in pages_needed:
                     pages_needed.append(page_label)
 
-        for page in reversed(pages_needed):
+        for page in pages_needed:
             scw = Gtk.ScrolledWindow()
             scw.set_shadow_type(Gtk.ShadowType.IN)
             list_box = Gtk.ListBox()


### PR DESCRIPTION
Currently the kernel window shows the oldest series first on the left side, but the newest version within that series first on the right side. This is inconsistent and also not desirable - the newest series should be shown first.