### PR TITLE
Allow arguments to be parsed

### DIFF
--- a/usr/bin/mintupdate
+++ b/usr/bin/mintupdate
@@ -1,6 +1,3 @@
-#!/usr/bin/python3
+#!/bin/bash
 
-import os
-
-command = "/usr/lib/linuxmint/mintUpdate/mintUpdate.py show &"
-os.system(command)
+/usr/lib/linuxmint/mintUpdate/mintUpdate.py $@ &

--- a/usr/bin/mintupdate
+++ b/usr/bin/mintupdate
@@ -1,3 +1,41 @@
-#!/bin/bash
+#!/usr/bin/python3
 
-/usr/lib/linuxmint/mintUpdate/mintUpdate.py $@ &
+import os
+import sys
+import subprocess
+import argparse
+
+if __name__ == "__main__":
+
+    # Parse arguments
+    parser = argparse.ArgumentParser(prog="mintupdate", description="The Linux Mint update manager")
+    parser.add_argument("-n", "--no-show", action="store_true", help="don't show the update manager window")
+    parser.add_argument("-v", "--version", action="version", version="mintUpdate 5.4.1", help="display the current version")
+    parser.add_argument("-f", "--force", action="store_true", help="force-start a fresh instance")
+
+    args = parser.parse_args()
+
+    # Check if there are any active instances of mintUpdate running in the background.
+    # If there are, then the current instance is the first instance of mintUpdate.
+    firstInstance = False
+    try:
+        output = subprocess.check_output("pgrep mintUpdate", shell = True)
+    except:
+        firstInstance = True
+
+    # If this is not the first instance and the user did not attempt to force-start mintUpdate, display the following messages
+    if not firstInstance and args.force == False:
+        print("mintUpdate is running in the background.\n")
+        print("If you would like to force-start a fresh instance of mintUpdate, please enter 'mintupdate -f' in the command line.")
+        sys.exit(0)
+
+    command = "/usr/lib/linuxmint/mintUpdate/mintUpdate.py"
+
+    if args.no_show:
+        command += " --no-show"
+
+    if not firstInstance:
+        command += " --force"
+
+    command += " &"
+    os.system(command)

--- a/usr/bin/mintupdate-launcher
+++ b/usr/bin/mintupdate-launcher
@@ -4,4 +4,4 @@ import os
 import xapp.os
 
 if ((not xapp.os.is_live_session()) and (not xapp.os.is_guest_session())):
-	os.system("/usr/lib/linuxmint/mintUpdate/mintUpdate.py --no-show &")
+    os.system("/usr/lib/linuxmint/mintUpdate/mintUpdate.py --no-show &")

--- a/usr/bin/mintupdate-launcher
+++ b/usr/bin/mintupdate-launcher
@@ -4,4 +4,4 @@ import os
 import xapp.os
 
 if ((not xapp.os.is_live_session()) and (not xapp.os.is_guest_session())):
-	os.system("/usr/lib/linuxmint/mintUpdate/mintUpdate.py &")
+	os.system("/usr/lib/linuxmint/mintUpdate/mintUpdate.py --no-show &")

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -31,32 +31,18 @@ from Classes import Update
 
 setproctitle.setproctitle("mintUpdate")
 
-# Parsing arguments
-parser = argparse.ArgumentParser(prog="mintupdate", description="The Linux Mint update manager")
-parser.add_argument("-n", "--no-show", action="store_true", help="don't show the update manager window")
-parser.add_argument("-v", "--version", action="store_true", help="display the current version")
-parser.add_argument("-f", "--force", action="store_true", help="force-start a fresh instance")
+# Parse arguments
+parser = argparse.ArgumentParser()
+parser.add_argument("--no-show", action="store_true")
+parser.add_argument("--force", action="store_true")
 
 args = parser.parse_args()
 
-# Display the version if the user requested to
-if args.version:
-    print("mintUpdate 5.4.1")
-    if args.no_show == False and args.force == False:
-        sys.exit(0)
-
-# Check if there are any active instances of mintUpdate running in the background.
-# If there are, then the current instance is the first instance of mintUpdate.
-output = subprocess.check_output("pgrep mintUpdate", shell = True).strip().decode("UTF-8").split('\n')
-if len(output) == 1:
-    firstInstance = True
-else:
+# If the user force-started a fresh instance of mintUpdate, this is not the first instance of mintUpdate
+if args.force:
     firstInstance = False
-
-if firstInstance == False and args.force == False:
-    print("mintUpdate is running in the background.")
-    print("If you would like to force-start a fresh instance of mintUpdate, please enter 'mintupdate -f' in the command line.")
-    sys.exit(0)
+else:
+    firstInstance = True
 
 # Whether the mintUpdate window needs to be shown
 if args.no_show:
@@ -1478,7 +1464,7 @@ class MintUpdate():
         self.app_hidden = True
         if not firstInstance:
             try:
-                os.system("kill -s 9 " + str(os.getpid()))
+                os.system("kill -9 %s &" % os.getpid())
             except Exception as e:
                 print (e)
                 print(sys.exc_info()[0])
@@ -1497,7 +1483,7 @@ class MintUpdate():
         self.app_hidden = True
         if not firstInstance:
             try:
-                os.system("kill -s 9 " + str(os.getpid()))
+                os.system("kill -9 %s &" % os.getpid())
             except Exception as e:
                 print (e)
                 print(sys.exc_info()[0])

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -786,7 +786,7 @@ class RefreshThread(threading.Thread):
                             model.set_value(iter, UPDATE_LEVEL_PIX, pixbuf)
                             model.set_value(iter, UPDATE_OLD_VERSION, update.old_version)
                             model.set_value(iter, UPDATE_NEW_VERSION, update.new_version)
-                            model.set_value(iter, UPDATE_SOURCE, "%s (%s)" % (origin, update.site))
+                            model.set_value(iter, UPDATE_SOURCE, "%s / %s" % (origin, update.archive))
                             model.set_value(iter, UPDATE_LEVEL_STR, str(update.level))
                             model.set_value(iter, UPDATE_SIZE, update.size)
                             model.set_value(iter, UPDATE_SIZE_STR, size_to_string(update.size))
@@ -1159,25 +1159,25 @@ class MintUpdate():
             selection.connect("changed", self.display_selected_package)
             self.builder.get_object("notebook_details").connect("switch-page", self.switch_page)
             self.window.connect("delete_event", self.close_window)
-            
-            # Apply button
-            apply_button = self.builder.get_object("tool_apply")
-            apply_button.connect("clicked", self.install)
+
+            # Install Updates button
+            install_button = self.builder.get_object("tool_apply")
+            install_button.connect("clicked", self.install)
             key, mod = Gtk.accelerator_parse("<Control>I")
-            apply_button.add_accelerator("clicked", accel_group, key, mod, Gtk.AccelFlags.VISIBLE)
-            
+            install_button.add_accelerator("clicked", accel_group, key, mod, Gtk.AccelFlags.VISIBLE)
+
             # Clear button
             clear_button = self.builder.get_object("tool_clear")
             clear_button.connect("clicked", self.clear)
-            key, mod = Gtk.accelerator_parse("<Shift><Control>A")
+            key, mod = Gtk.accelerator_parse("<Control><Shift>A")
             clear_button.add_accelerator("clicked", accel_group, key, mod, Gtk.AccelFlags.VISIBLE)
-            
+
             # Select All button
             select_all_button = self.builder.get_object("tool_select_all")
             select_all_button.connect("clicked", self.select_all)
             key, mod = Gtk.accelerator_parse("<Control>A")
             select_all_button.add_accelerator("clicked", accel_group, key, mod, Gtk.AccelFlags.VISIBLE)
-            
+
             # Refresh button
             refresh_button = self.builder.get_object("tool_refresh")
             refresh_button.connect("clicked", self.force_refresh)
@@ -1349,53 +1349,53 @@ class MintUpdate():
                 print(sys.exc_info()[0])
             viewSubmenu.append(infoMenuItem)
 
-            # New select menu
+            # New 'Select' menu
             selectMenu = Gtk.MenuItem.new_with_label("Select")
             selectSubmenu = Gtk.Menu()
             selectMenu.set_submenu(selectSubmenu)
-            
+
             clearItem = Gtk.MenuItem.new_with_label("Clear")
             clearItem.connect("activate", self.clear)
             key, mod = Gtk.accelerator_parse("<Control><Shift>A")
             clearItem.add_accelerator("activate", accel_group, key, mod, Gtk.AccelFlags.VISIBLE)
             selectSubmenu.append(clearItem)
-            
+
             selectAllItem = Gtk.MenuItem.new_with_label("All")
             selectAllItem.connect("activate", self.select_all)
             key, mod = Gtk.accelerator_parse("<Control>A")
             selectAllItem.add_accelerator("activate", accel_group, key, mod, Gtk.AccelFlags.VISIBLE)
             selectSubmenu.append(selectAllItem)
-            
+
             selectLevel1Item = Gtk.MenuItem.new_with_label("Level 1")
             selectLevel1Item.connect("activate", self.select_level1)
             key, mod = Gtk.accelerator_parse("<Control>1")
             selectLevel1Item.add_accelerator("activate", accel_group, key, mod, Gtk.AccelFlags.VISIBLE)
             selectSubmenu.append(selectLevel1Item)
-            
+
             selectLevel2Item = Gtk.MenuItem.new_with_label("Level 2")
             selectLevel2Item.connect("activate", self.select_level2)
             key, mod = Gtk.accelerator_parse("<Control>2")
             selectLevel2Item.add_accelerator("activate", accel_group, key, mod, Gtk.AccelFlags.VISIBLE)
             selectSubmenu.append(selectLevel2Item)
-            
+
             selectLevel3Item = Gtk.MenuItem.new_with_label("Level 3")
             selectLevel3Item.connect("activate", self.select_level3)
             key, mod = Gtk.accelerator_parse("<Control>3")
             selectLevel3Item.add_accelerator("activate", accel_group, key, mod, Gtk.AccelFlags.VISIBLE)
             selectSubmenu.append(selectLevel3Item)
-            
+
             selectLevel4Item = Gtk.MenuItem.new_with_label("Level 4")
             selectLevel4Item.connect("activate", self.select_level4)
             key, mod = Gtk.accelerator_parse("<Control>4")
             selectLevel4Item.add_accelerator("activate", accel_group, key, mod, Gtk.AccelFlags.VISIBLE)
             selectSubmenu.append(selectLevel4Item)
-            
+
             selectSecurityItem = Gtk.MenuItem.new_with_label("Security")
             selectSecurityItem.connect("activate", self.select_security_updates)
             key, mod = Gtk.accelerator_parse("<Control>S")
             selectSecurityItem.add_accelerator("activate", accel_group, key, mod, Gtk.AccelFlags.VISIBLE)
             selectSubmenu.append(selectSecurityItem)
-            
+
             selectKernelItem = Gtk.MenuItem.new_with_label("Kernel")
             selectKernelItem.connect("activate", self.select_kernel_updates)
             key, mod = Gtk.accelerator_parse("<Control>K")

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -33,7 +33,7 @@ setproctitle.setproctitle("mintUpdate")
 
 # Parsing arguments
 parser = argparse.ArgumentParser(prog="mintupdate", description="The Linux Mint update manager")
-parser.add_argument("-n", "--no-show", action="store_true", help="don't show the update manager")
+parser.add_argument("-n", "--no-show", action="store_true", help="don't show the update manager window")
 parser.add_argument("-v", "--version", action="store_true", help="display the current version")
 parser.add_argument("-f", "--force", action="store_true", help="force-start a fresh instance")
 


### PR DESCRIPTION
Applies to #355

Arguments added:
`-n / --no-show: Don't show the update manager window`
`-v / --version: Display the current version`
`-f / --force: Force-start a fresh instance`

If the user wants to force-start a new instance of mintUpdate, the `-f` / `--force` option could be used.

The first instance of mintUpdate is not killed (and remains running in the background) when the user closes the update manager window.

For instances of mintUpdate other than the first instance, once the user closes the update manager window, that instance of mintUpdate is killed to preserve system memory.