### PR TITLE
Only use Ubuntu kernel meta packages for kernel updates

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -118,7 +118,7 @@ class APTCheck():
                         meta = self.cache[meta_name]
                         if meta.is_installed:
                             meta_installed = True
-                            break
+                            return
 
                 # If no meta is installed, try to recommend one
                 if not meta_installed:
@@ -138,10 +138,9 @@ class APTCheck():
                 if self.settings.get_boolean("use-lowlatency-kernels"):
                     kernel_type = "-lowlatency"
                 for pkg in self.cache:
-                    package_name = pkg.name
-                    if (package_name.startswith("linux-image-3") or package_name.startswith("linux-image-4")) and package_name.endswith(kernel_type):
-                        version = package_name.replace("linux-image-", "").replace("-generic", "").replace("-lowlatency", "")
-                        kernel = KernelVersion(version)
+                    match = re.match(r'^(?:linux-image-)(?:unsigned-)?(\d.+?)' + kernel_type + '$', pkg.name)
+                    if match:
+                        kernel = KernelVersion(match.group(1))
                         if kernel.numeric_representation > max_kernel.numeric_representation and kernel.series == max_kernel.series:
                             max_kernel = kernel
                 if max_kernel.numeric_representation != uname_kernel.numeric_representation:

--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -137,9 +137,8 @@ class APTCheck():
                 kernel_type = "-generic"
                 if self.settings.get_boolean("use-lowlatency-kernels"):
                     kernel_type = "-lowlatency"
-                for pkg in self.cache:
-                    match = re.match(r'^(?:linux-image-)(?:unsigned-)?(\d.+?)' + kernel_type + '$', pkg.name)
-                    if match:
+                for pkgname in self.cache.keys():
+                    match = re.match(r'^(?:linux-image-)(?:unsigned-)?(\d.+?)' + kernel_type + '$', pkgname)                    if match:
                         kernel = KernelVersion(match.group(1))
                         if kernel.numeric_representation > max_kernel.numeric_representation and kernel.series == max_kernel.series:
                             max_kernel = kernel


### PR DESCRIPTION
Fixes #369 that I reported a while ago. I still consider it a bug although I never got any feedback.

This also prevents the behaviour where with a `linux-generic` installed, Update Manager will list kernel updates twice.

I also replaced the kernel package detection with the same regex I used in the mainline removal patch for the same reasons, except we should never reach that code now (on Ubuntu base - none of the kernel code works on Debian, anyway).
