### PR TITLE
Fix kernel update type detection

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/Classes.py
+++ b/usr/lib/linuxmint/mintUpdate/Classes.py
@@ -84,7 +84,7 @@ class Update():
                         if origin.component == "romeo":
                             self.type = "unstable"
                             break
-                if self.source_name in ["linux", "linux-kernel"]:
+                if self.real_source_name in ["linux", "linux-kernel", "linux-signed", "linux-meta"]:
                     self.type = "kernel"
 
             self.level = 2 # Level 2 by default


### PR DESCRIPTION
Kernel type updates aren't properly categorized at the moment, except for packages added via the bug I fixed in #405. This corrects that.