### PR TITLE
[WIP] Allow turning autorefresh on and off

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/Classes.py
+++ b/usr/lib/linuxmint/mintUpdate/Classes.py
@@ -84,7 +84,7 @@ class Update():
                         if origin.component == "romeo":
                             self.type = "unstable"
                             break
-                if self.source_name in ["linux", "linux-kernel"]:
+                if self.real_source_name in ["linux", "linux-kernel", "linux-signed", "linux-meta"]:
                     self.type = "kernel"
 
             self.level = 2 # Level 2 by default

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -1414,8 +1414,9 @@ class MintUpdate():
             self.window.resize(self.settings.get_int('window-width'), self.settings.get_int('window-height'))
             self.builder.get_object("paned1").set_position(self.settings.get_int('window-pane-position'))
 
-            auto_refresh = AutomaticRefreshThread(self)
-            auto_refresh.start()
+            if self.settings.get_boolean("enable-autorefresh"):
+                auto_refresh = AutomaticRefreshThread(self)
+                auto_refresh.start()
 
             Gdk.threads_enter()
             Gtk.main()
@@ -1898,6 +1899,7 @@ class MintUpdate():
         builder.get_object("checkbutton_default_repo_is_ok").set_active(self.settings.get_boolean("default-repo-is-ok"))
         builder.get_object("checkbutton_warning_timeshift").set_active(self.settings.get_boolean("warn-about-timeshift"))
         builder.get_object("auto_updates_checkbox").set_active(os.path.exists(CRON_JOB))
+        builder.get_object("checkbutton_autorefresh").set_active(self.settings.get_boolean("enable-autorefresh"))
 
         builder.get_object("refresh_days").set_range(0, 365)
         builder.get_object("refresh_days").set_increments(1, 10)
@@ -1967,6 +1969,7 @@ class MintUpdate():
         self.settings.set_int('autorefresh-hours', int(builder.get_object("autorefresh_hours").get_value()))
         self.settings.set_int('autorefresh-minutes', int(builder.get_object("autorefresh_minutes").get_value()))
         self.settings.set_boolean('dist-upgrade', builder.get_object("checkbutton_dist_upgrade").get_active())
+        self.settings.set_boolean('enable-autorefresh', builder.get_object("checkbutton_autorefresh").get_active())
         blacklist = []
         treeview_blacklist = builder.get_object("treeview_blacklist")
         model = treeview_blacklist.get_model()

--- a/usr/share/glib-2.0/schemas/com.linuxmint.updates.gschema.xml
+++ b/usr/share/glib-2.0/schemas/com.linuxmint.updates.gschema.xml
@@ -86,12 +86,17 @@
       <summary></summary>
       <description></description>
     </key>
+    <key type="b" name="enable-autorefresh">
+      <default>true</default>
+      <summary></summary>
+      <description></description>
+    </key>
     <key type="as" name="blacklisted-packages">
       <default>[]</default>
       <summary></summary>
       <description></description>
     </key>
-        <key type="i" name="refresh-days">
+      <key type="i" name="refresh-days">
       <default>0</default>
       <summary></summary>
       <description></description>

--- a/usr/share/linuxmint/mintupdate/preferences.ui
+++ b/usr/share/linuxmint/mintupdate/preferences.ui
@@ -990,6 +990,22 @@
                 <property name="position">11</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkCheckButton" id="checkbutton_autorefresh">
+                <property name="label" translatable="yes">Enable auto-refresh</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="margin_left">24</property>
+                <property name="xalign">0</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">12</property>
+              </packing>
+            </child>
           </object>
         </child>
       </object>


### PR DESCRIPTION
By default, auto-refresh is enabled and cannot be disabled by the user.

A check button is added for turning auto-refresh on and off.

When auto-refresh is off, no AutomaticRefreshThread would be started.

After updating the schema file, the user needs to re-compile the schema files by executing the following commands in a terminal:
`sudo -i` <-- Gain root access
`glib-compile-schemas --targetdir=/usr/share/glib-2.0/schemas /usr/share/glib-2.0/schemas`

This prevents an error from Glib saying that no key named "enable-autorefresh" is found in the setting schemas.

A screenshot of the new preferences window from this pull request:
![new preferences window](https://user-images.githubusercontent.com/23616009/48392452-656a6a80-e746-11e8-9eaa-d33ae6468155.png)