### PR TITLE
Run automatic updates in non-interactive mode

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintupdate-cli.py
+++ b/usr/lib/linuxmint/mintUpdate/mintupdate-cli.py
@@ -28,6 +28,7 @@ if __name__ == "__main__":
     parser.add_argument("-r", "--refresh-cache", action="store_true", help="refresh the APT cache")
     parser.add_argument("-d", "--dry-run", action="store_true", help="simulation mode, don't upgrade anything")
     parser.add_argument("-y", "--yes", action="store_true", help="automatically answer yes to all questions")
+    parser.add_argument("--noninteractive", action="store_true", help="avoid configuration questions from Debconf, used for automatic updates")
     parser.add_argument("--install-recommends", action="store_true", help="install recommended packages (use with caution)")
 
     args = parser.parse_args()
@@ -78,7 +79,12 @@ if __name__ == "__main__":
                 arguments.append("-y")
             if args.install_recommends:
                 arguments.append("--install-recommends")
-            subprocess.call(arguments + packages)
+            if args.noninteractive:
+                environment = os.environ
+                environment.update({"DEBIAN_FRONTEND": "noninteractive"})
+            else:
+                environment = None
+            subprocess.call(arguments + packages, env=environment)
     except Exception as error:
         traceback.print_exc()
         sys.exit(1)

--- a/usr/share/linuxmint/mintupdate/cron_job.default
+++ b/usr/share/linuxmint/mintupdate/cron_job.default
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/usr/bin/mintupdate-cli upgrade --refresh-cache --yes > /var/log/mintupdate.log 2>&1
+/usr/bin/mintupdate-cli upgrade --refresh-cache --yes --noninteractive > /var/log/mintupdate.log 2>&1


### PR DESCRIPTION
When running automatic updates, this prevents debconf to ask things to the user
and to wait endlessly (because it is not possible for the user to answer).

When this happened, some package were left unconfigured and user had to open a
terminal to type "sudo dpkg --configure -a" to be able to install/update
software again.

See #376 