### PR TITLE
Fix kernel update type detection v2

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/Classes.py
+++ b/usr/lib/linuxmint/mintUpdate/Classes.py
@@ -84,7 +84,7 @@ class Update():
                         if origin.component == "romeo":
                             self.type = "unstable"
                             break
-                if self.real_source_name in ["linux", "linux-kernel", "linux-signed", "linux-meta"]:
+                if package.candidate.section == "kernel" or self.package_name.startswith("linux-headers") or self.real_source_name in ["linux", "linux-kernel", "linux-signed", "linux-meta"]:
                     self.type = "kernel"
 
             self.level = 2 # Level 2 by default


### PR DESCRIPTION
The fix in #407 will break on hwe kernels and rather than add linux-hwe, linux-signed-hwe, linux-hwe-edge, linux-signed-hwe-edge and what not the more generic approach should catch them all. I left the existing source name comparison as well just in case.