### PR TITLE
Only show "Supported until" for latest supported kernel in a series, …

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -335,7 +335,9 @@ class KernelWindow():
 
                 kernel_support_info[release].append([page_label, support_duration, support_end_str, is_end_of_life])
 
+        kernel_list_prelim.sort(reverse=True)
         kernel_list = []
+        supported_list = []
         for kernel in kernel_list_prelim:
             (version_id, version, pkg_version, page_label, label, installed, used, title, installable, origin, release, support_duration) = kernel
             support_status = ""
@@ -347,17 +349,20 @@ class KernelWindow():
                 if support_info:
                     (page_label, support_duration, support_end_str, is_end_of_life) = support_info[0]
                     if support_end_str:
-                        support_status = '%s %s' % (_("Supported until"), support_end_str)
+                        if not page_label in supported_list:
+                            supported_list.append(page_label)
+                            support_status = '%s %s' % (_("Supported until"), support_end_str)
+                        else:
+                            support_status = '<span foreground="orange">%s</span>' % _("Superseded")
                     elif is_end_of_life:
                         support_status = '<span foreground="red">%s</span>' % _("End of Life")
             else:
                 support_status = '<span foreground="red">%s</span>' % _("Unsupported")
             kernel_list.append([version_id, version, pkg_version, page_label, label, installed, used, title, installable, origin, support_status])
         del(kernel_list_prelim)
-
-        kernel_list.sort(reverse=True)
         pages_needed_sort.sort(reverse=True)
 
+        pages_needed_sort.sort(reverse=True)
         for page in pages_needed_sort:
             page = page[1]
             scw = Gtk.ScrolledWindow()
@@ -374,7 +379,7 @@ class KernelWindow():
                 (version_id, version, pkg_version, page_label, label, installed, used, title, installable, origin, support_status) = kernel
                 if used:
                     currently_using = _("You are currently using the following kernel:")
-                    current_label.set_markup("<b>%s %s</b>" % (currently_using, label))
+                    current_label.set_markup("<b>%s %s%s</b>" % (currently_using, label, " (%s)" % support_status if support_status else support_status))
                 if page_label == page:
                     row = KernelRow(version, pkg_version, label, installed, used, title, installable, origin, support_status, self.window, self.application)
                     list_box.add(row)

--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -353,11 +353,11 @@ class KernelWindow():
                             supported_list.append(page_label)
                             support_status = '%s %s' % (_("Supported until"), support_end_str)
                         else:
-                            support_status = '<span foreground="orange">%s</span>' % _("Superseded")
+                            support_status = _("Superseded")
                     elif is_end_of_life:
-                        support_status = '<span foreground="red">%s</span>' % _("End of Life")
+                        support_status = _("End of Life")
             else:
-                support_status = '<span foreground="red">%s</span>' % _("Unsupported")
+                support_status = _("Unsupported")
             kernel_list.append([version_id, version, pkg_version, page_label, label, installed, used, title, installable, origin, support_status])
         del(kernel_list_prelim)
         pages_needed_sort.sort(reverse=True)


### PR DESCRIPTION
…mark older as "Superseded" and also add support status to current kernel label

After receiving some feedback I feel this would improve upon my original implementation. 
![](https://i.imgur.com/0MWir15.png)

The second commit removes the colors completely for better theme compatibility, there was no good way to make them work with themes.