### PR TITLE
Kernelwindow: Fix "Remove old kernels" related issues

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -234,7 +234,6 @@ class KernelWindow():
         builder.get_object("button_massremove").connect("clicked", self.show_remove_kernels_window, self.remove_kernels_window)
 
         # Set up the kernel mass removal confirmation window
-        self.remove_kernels_window.connect("destroy", self.on_cancel_clicked, self.remove_kernels_window)
         builder.get_object("b_cancel").connect("clicked", self.on_cancel_clicked, self.remove_kernels_window)
         builder.get_object("b_remove").connect("clicked", self.on_remove_clicked, self.remove_kernels_window)
         remove_kernels_listbox = builder.get_object("box_list")

--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -234,6 +234,7 @@ class KernelWindow():
         builder.get_object("button_massremove").connect("clicked", self.show_remove_kernels_window, self.remove_kernels_window)
 
         # Set up the kernel mass removal confirmation window
+        self.remove_kernels_window.connect("destroy", self.on_cancel_clicked, self.remove_kernels_window)
         builder.get_object("b_cancel").connect("clicked", self.on_cancel_clicked, self.remove_kernels_window)
         builder.get_object("b_remove").connect("clicked", self.on_remove_clicked, self.remove_kernels_window)
         remove_kernels_listbox = builder.get_object("box_list")
@@ -429,3 +430,5 @@ class KernelWindow():
             thread = InstallKernelThread(self.marked_kernels, self.application)
             thread.start()
             self.window.hide()
+        else:
+            self.window.set_sensitive(True)

--- a/usr/share/linuxmint/mintupdate/kernels.ui
+++ b/usr/share/linuxmint/mintupdate/kernels.ui
@@ -422,8 +422,8 @@
     <property name="border_width">6</property>
     <property name="title" translatable="yes">Remove old kernels...</property>
     <property name="modal">True</property>
-    <property name="deletable">False</property>
     <property name="type_hint">dialog</property>
+    <property name="deletable">False</property>
     <property name="transient_for">window1</property>
     <child type="titlebar">
       <placeholder/>
@@ -477,6 +477,7 @@
           <object class="GtkLabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="margin_left">20</property>
             <property name="label" translatable="yes">Select the kernels you want to remove:</property>
             <property name="wrap">True</property>
             <property name="xalign">0</property>

--- a/usr/share/linuxmint/mintupdate/kernels.ui
+++ b/usr/share/linuxmint/mintupdate/kernels.ui
@@ -422,6 +422,7 @@
     <property name="border_width">6</property>
     <property name="title" translatable="yes">Remove old kernels...</property>
     <property name="modal">True</property>
+    <property name="deletable">False</property>
     <property name="type_hint">dialog</property>
     <property name="transient_for">window1</property>
     <child type="titlebar">


### PR DESCRIPTION
Apparently my theme was missing the X button but it was there. Whoops. Remove it for everyone.
Also fixes an issue when remove is clicked but nothing was selected, and aligns the "Select the kernels.." label with the box below.