### PR TITLE
checkAPT: Only run mintinstall-update-pkgcache when root

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -357,7 +357,7 @@ if __name__ == "__main__":
         check.apply_aliases()
         check.clean_descriptions()
         check.serialize_updates()
-        if os.path.exists("/usr/bin/mintinstall-update-pkgcache"):
+        if os.getuid() == 0 and os.path.exists("/usr/bin/mintinstall-update-pkgcache"):
             # Spawn the cache update asynchronously
             # We're using os.system with & here to make sure it's async and detached
             # from the caller (which will die before the child process is finished)


### PR DESCRIPTION
Currently `mintinstall-update-pkgcache` is called on every refresh, slowing down the user's session startup for no good reason when all mintinstall cares about are updated package lists, which only get retrieved when checkAPT is run in root mode. 

mintinstall does open its own apt cache instance, anyway, it does not need realtime external updates like my #441 adds to Update Manager. This change here is however important with respect to the latter as well to avoid undue performance impact.