### PR TITLE
Handle dpkg lock

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,7 @@ Depends:
  ${misc:Depends},
  lsb-release,
  inxi,
+ psmisc,
  python3-apt,
  python3-pycurl,
  python3-setproctitle,

--- a/etc/sudoers.d/mintupdate
+++ b/etc/sudoers.d/mintupdate
@@ -3,3 +3,4 @@
 
 ALL ALL = NOPASSWD:/usr/lib/linuxmint/mintUpdate/checkAPT.py
 ALL ALL = NOPASSWD:/usr/lib/linuxmint/mintUpdate/synaptic-workaround.py
+ALL ALL = NOPASSWD:/usr/lib/linuxmint/mintUpdate/dpkg_lock_check.sh

--- a/usr/lib/linuxmint/mintUpdate/dpkg_lock_check.sh
+++ b/usr/lib/linuxmint/mintUpdate/dpkg_lock_check.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+/bin/fuser /var/lib/dpkg/lock

--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -189,9 +189,12 @@ class KernelRow(Gtk.ListBoxRow):
         d.hide()
         d.destroy()
         if r == Gtk.ResponseType.YES:
-            thread = InstallKernelThread([[version, installed]], self.application)
-            thread.start()
-            window.hide()
+            if self.application.dpkg_locked():
+                self.application.show_dpkg_lock_msg(window)
+            else:
+                thread = InstallKernelThread([[version, installed]], self.application)
+                thread.start()
+                window.hide()
 
 class KernelWindow():
     def __init__(self, application):
@@ -436,8 +439,12 @@ class KernelWindow():
     def on_remove_clicked(self, widget, window):
         window.hide()
         if self.marked_kernels:
-            thread = InstallKernelThread(self.marked_kernels, self.application)
-            thread.start()
-            self.window.hide()
+            if self.application.dpkg_locked():
+                self.application.show_dpkg_lock_msg(self.window)
+                self.window.set_sensitive(True)
+            else:
+                thread = InstallKernelThread(self.marked_kernels, self.application)
+                thread.start()
+                self.window.hide()
         else:
             self.window.set_sensitive(True)


### PR DESCRIPTION
Checks for open handles on `/var/lib/dpkg/lock` and prevents update/refresh/kernel operations in this case. Scheduled refresh operations will automatically retry every 60s.

edit: I hadn't even noticed that there was existing code trying to handle this for refreshes only - it didn't work correctly because it only checked for certain active processes, not even including the apt binary itself. I removed all of that in favour of my comprehensive solution.

Includes the sudoers addition from #428