### PR TITLE
Point to "apt update" on release information change

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -647,6 +647,8 @@ class RefreshThread(threading.Thread):
             elif ("CHECK_APT_ERROR" in output):
                 try:
                     error_msg = output.split("Error: ")[1].replace("E:", "\n").strip()
+                    if "apt.cache.FetchFailedException" in output and " changed its " in error_msg:
+                        error_msg += "\n\n%s" % _("Run 'apt update' in a terminal window to address this")
                 except:
                     error_msg = ""
                 Gdk.threads_enter()


### PR DESCRIPTION
Since popular repositories seems to change their information often these days (google, opera, vivaldi, winehq to name but a few) but it's still a good idea not to automatically accept such changes, this amends the error message with _Run 'apt update' in a terminal window to address this_ to hopefully confuse a few users less. 

Note that this does not affect manual refreshes while the window is open because then synaptic gets used.

Also note that it is my understanding that python-apt's apt_pkg.Error class always returns a non-localized error message, otherwise this change simply won't do anything on localized installs.