### PR TITLE
Kernelwindow: Add optional kernel flavour selector

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/Classes.py
+++ b/usr/lib/linuxmint/mintUpdate/Classes.py
@@ -11,15 +11,15 @@ from gi.repository import Gio
 PRIORITY_UPDATES = ['mintupdate', 'mint-upgrade-info']
 
 settings = Gio.Settings("com.linuxmint.updates")
-if settings.get_boolean("use-lowlatency-kernels"):
-    CONFIGURED_KERNEL_TYPE = "-lowlatency"
-else:
-    CONFIGURED_KERNEL_TYPE = "-generic"
 
 SUPPORTED_KERNEL_TYPES = ["-generic", "-lowlatency", "-aws", "-azure", "-gcp", "-kvm", "-oem", "-oracle"]
 KERNEL_PKG_NAMES = ['linux-headers-VERSION', 'linux-headers-VERSION-KERNELTYPE', 'linux-image-VERSION-KERNELTYPE', \
     'linux-modules-VERSION-KERNELTYPE', 'linux-modules-extra-VERSION-KERNELTYPE']
 KERNEL_PKG_NAMES.append('linux-image-extra-VERSION-KERNELTYPE') # Naming convention in 16.04, until 4.15 series
+
+CONFIGURED_KERNEL_TYPE = settings.get_string("selected-kernel-type")
+if CONFIGURED_KERNEL_TYPE not in SUPPORTED_KERNEL_TYPES:
+    CONFIGURED_KERNEL_TYPE = "-generic"
 
 def get_release_dates():
     """ Get distro release dates for support duration calculation """

--- a/usr/lib/linuxmint/mintUpdate/checkKernels.py
+++ b/usr/lib/linuxmint/mintUpdate/checkKernels.py
@@ -5,6 +5,9 @@ import os
 import re
 from Classes import CONFIGURED_KERNEL_TYPE, SUPPORTED_KERNEL_TYPES
 
+if len(sys.argv) > 1 and sys.argv[1] in SUPPORTED_KERNEL_TYPES:
+    CONFIGURED_KERNEL_TYPE = sys.argv[1]
+
 try:
     current_version = os.uname().release
     cache = apt.Cache()

--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -458,19 +458,11 @@ class KernelWindow():
                     currently_using = _("You are currently using the following kernel:")
                     self.current_label.set_markup("<b>%s %s%s</b>" % (currently_using, label, " (%s)" % support_status if support_status else support_status))
                 if page_label == page:
-                    row = KernelRow(version, pkg_version, kernel_type, label, installed, used, title, installable, origin, support_status, self.window, self.application)
+                    row = KernelRow(version, pkg_version, kernel_type, label, installed, used, title,
+                        installable, origin, support_status, self.window, self.application)
                     list_box.add(row)
 
             list_box.connect("row_activated", self.on_row_activated)
-
-        self.main_stack.add_named(main_box, "main_box")
-
-        if self.application.settings.get_boolean("hide-kernel-update-warning"):
-            self.main_stack.set_visible_child(main_box)
-        else:
-            self.main_stack.set_visible_child(info_box)
-
-        self.window.show_all()
 
     def destroy_window(self, widget):
         self.window.destroy()

--- a/usr/share/glib-2.0/schemas/com.linuxmint.updates.gschema.xml
+++ b/usr/share/glib-2.0/schemas/com.linuxmint.updates.gschema.xml
@@ -196,13 +196,18 @@
       <summary></summary>
       <description></description>
     </key>
-    <key type="b" name="use-lowlatency-kernels">
+    <key type="b" name="allow-kernel-type-selection">
       <default>false</default>
       <summary></summary>
       <description></description>
     </key>
     <key type="b" name="warn-about-distribution-eol">
       <default>true</default>
+      <summary></summary>
+      <description></description>
+    </key>
+    <key type="s" name="selected-kernel-type">
+      <default>"-generic"</default>
       <summary></summary>
       <description></description>
     </key>

--- a/usr/share/linuxmint/mintupdate/kernels.ui
+++ b/usr/share/linuxmint/mintupdate/kernels.ui
@@ -282,7 +282,7 @@
     <property name="orientation">vertical</property>
     <property name="spacing">12</property>
     <child>
-      <object class="GtkLabel" id="label6">
+      <object class="GtkLabel" id="current_label">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="margin_top">6</property>
@@ -365,34 +365,85 @@
       </packing>
     </child>
     <child>
-      <object class="GtkButtonBox" id="buttonbox1">
+      <object class="GtkButtonBox" id="bottom_row">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">6</property>
-        <property name="layout_style">end</property>
         <child>
-          <object class="GtkButton" id="button_massremove">
-            <property name="label" translatable="yes">Remove old kernels...</property>
+          <object class="GtkButtonBox" id="buttonbox_left">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
+            <property name="can_focus">False</property>
+            <property name="spacing">6</property>
+            <property name="layout_style">start</property>
+            <child>
+              <object class="GtkLabel" id="cb_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="no_show_all">True</property>
+                <property name="label" translatable="yes">Kernel flavour:</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkComboBoxText" id="cb_kernel_type">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="no_show_all">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">True</property>
+            <property name="fill">False</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkButton" id="button_close">
-            <property name="label" translatable="yes">Close</property>
+          <object class="GtkButtonBox" id="buttonbox_right">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">6</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="button_massremove">
+                <property name="label" translatable="yes">Remove old kernels...</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_close">
+                <property name="label" translatable="yes">Close</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">True</property>
+            <property name="fill">False</property>
             <property name="position">1</property>
           </packing>
         </child>


### PR DESCRIPTION
Adds this:
![kernel-flavour](https://user-images.githubusercontent.com/13855078/50986045-13578280-1506-11e9-9857-6a02a30ae1da.png)

Only shows when `com.linuxmint.updates.allow-kernel-type-selection` is set in gsettings, which replaces the old `use-lowlatency-kernels` that was never properly implemented. Whether a GUI toggle in the Preferences window is desired can be decided later.

Includes #434 and https://github.com/linuxmint/mintupdate/commit/f1c76074624dd24327b8e05ae55d6e73957ee026 from #454 