### PR TITLE
Add distribution end of life warning and status

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/Classes.py
+++ b/usr/lib/linuxmint/mintUpdate/Classes.py
@@ -21,6 +21,31 @@ KERNEL_PKG_NAMES = ['linux-headers-VERSION', 'linux-headers-VERSION-KERNELTYPE',
     'linux-modules-VERSION-KERNELTYPE', 'linux-modules-extra-VERSION-KERNELTYPE']
 KERNEL_PKG_NAMES.append('linux-image-extra-VERSION-KERNELTYPE') # Naming convention in 16.04, until 4.15 series
 
+def get_release_dates():
+    """ Get distro release dates for support duration calculation """
+    import os
+    import time
+    from datetime import datetime
+
+    release_dates = {}
+    distro_info = []
+    if os.path.isfile("/usr/share/distro-info/ubuntu.csv"):
+        distro_info += open("/usr/share/distro-info/ubuntu.csv", "r").readlines()
+    if os.path.isfile("/usr/share/distro-info/debian.csv"):
+        distro_info += open("/usr/share/distro-info/debian.csv", "r").readlines()
+    if distro_info:
+        for distro in distro_info[1:]:
+            try:
+                distro = distro.split(",")
+                release_date = time.mktime(time.strptime(distro[4], '%Y-%m-%d'))
+                release_date = datetime.fromtimestamp(release_date)
+                support_end = time.mktime(time.strptime(distro[5].rstrip(), '%Y-%m-%d'))
+                support_end = datetime.fromtimestamp(support_end)
+                release_dates[distro[2]] = [release_date, support_end]
+            except:
+                pass
+    return release_dates
+
 class Rule():
 
     def __init__(self, name, version, level):

--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -262,7 +262,7 @@ class KernelWindow():
         # Get distro release dates for support duration calculation
         self.release_dates = get_release_dates()
 
-        now = datetime.datetime.now()
+        now = datetime.now()
         hwe_support_duration = {}
 
         try:

--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -12,6 +12,7 @@ import time
 from datetime import datetime
 import locale
 from apt.utils import get_maintenance_end_date
+from Classes import get_release_dates
 from Classes import KERNEL_PKG_NAMES, SUPPORTED_KERNEL_TYPES, CONFIGURED_KERNEL_TYPE
 
 KERNEL_INFO_DIR = "/usr/share/mint-kernel-info"
@@ -259,17 +260,9 @@ class KernelWindow():
         remove_kernels_listbox = builder.get_object("box_list")
 
         # Get distro release dates for support duration calculation
-        release_dates = {}
-        if os.path.isfile("/usr/share/distro-info/ubuntu.csv"):
-            distro_info = open("/usr/share/distro-info/ubuntu.csv", "r").readlines()
-            for distro in distro_info[1:]:
-                distro = distro.split(",")
-                release_date = time.mktime(time.strptime(distro[4], '%Y-%m-%d'))
-                release_date = datetime.fromtimestamp(release_date)
-                support_end = time.mktime(time.strptime(distro[5].rstrip(), '%Y-%m-%d'))
-                support_end = datetime.fromtimestamp(support_end)
-                release_dates[distro[2]] = [release_date, support_end]
-        now = datetime.now()
+        self.release_dates = get_release_dates()
+
+        now = datetime.datetime.now()
         hwe_support_duration = {}
 
         try:

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -652,7 +652,7 @@ class RefreshThread(threading.Thread):
         return (mint_layer_found, error_msg)
 
     @staticmethod
-    def get_eol_status(early_warning_days=90):
+    def get_eol_status():
         """ Checks if distribution has reached end of life (EOL)
 
         Returns:
@@ -660,6 +660,7 @@ class RefreshThread(threading.Thread):
         * show_eol_warning: True if early_warning_days > EOL - now
         * eol_date: datetime object of EOL date
         """
+        early_warning_days = 90
         is_eol = False
         eol_date = None
         show_eol_warning = False
@@ -1044,7 +1045,7 @@ class RefreshThread(threading.Thread):
 
     def _on_infobar_eol_response(self, infobar, response_id):
         infobar.destroy()
-        self.application.settings.set_boolean("warn-about-distribution-eol", 0)
+        self.application.settings.set_boolean("warn-about-distribution-eol", False)
 
     def get_url_last_modified(self, url):
         try:

--- a/usr/share/glib-2.0/schemas/com.linuxmint.updates.gschema.xml
+++ b/usr/share/glib-2.0/schemas/com.linuxmint.updates.gschema.xml
@@ -201,5 +201,10 @@
       <summary></summary>
       <description></description>
     </key>
+    <key type="b" name="warn-about-distribution-eol">
+      <default>true</default>
+      <summary></summary>
+      <description></description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Ninety days before the distribution reaches end of life an infobar is shown until confirmed, then after end of life is reached all status message and the tray icon will always indicate an error, pointing out the EOL status (if no other error occurred - once the repos get shut down the user will get the regular failure messages, anyway):

![eol-warning](https://user-images.githubusercontent.com/13855078/51139470-4bcbc900-1844-11e9-9c35-d722856aefe8.png)


Supports both Linux Mint and LMDE.

Closes #444

Depends on #478