### PR TITLE
Alias kernel updates only if meta or at least 3 packages in update

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -17,6 +17,8 @@ from Classes import Update, Alias, Rule, KERNEL_PKG_NAMES, CONFIGURED_KERNEL_TYP
 
 gettext.install("mintupdate", "/usr/share/locale")
 
+meta_names = []
+
 class KernelVersion():
 
     def __init__(self, version):
@@ -104,6 +106,7 @@ class APTCheck():
                 self.add_update(pkg)
 
         # Kernel updates
+        global meta_names
         meta_names = []
         _metas = [s for s in self.cache.keys() if s.startswith("linux" + CONFIGURED_KERNEL_TYPE)]
         for meta in _metas:
@@ -223,7 +226,10 @@ class APTCheck():
                 update.display_name = alias.name
                 update.short_description = alias.short_description
                 update.description = alias.description
-            elif update.type == "kernel" and source_name not in ['linux-libc-dev', 'linux-kernel-generic']:
+            elif (update.type == "kernel" and
+                  source_name not in ['linux-libc-dev', 'linux-kernel-generic'] and
+                  (len(update.package_names) >= 3 or update.package_names[0] in meta_names)
+                 ):
                 update.display_name = _("Linux kernel %s") % update.new_version
                 update.short_description = _("The Linux kernel.")
                 update.description = _("The Linux Kernel is responsible for hardware and drivers support. Note that this update will not remove your existing kernel. You will still be able to boot with the current kernel by choosing the advanced options in your boot menu. Please be cautious though.. kernel regressions can affect your ability to connect to the Internet or to log in graphically. DKMS modules are compiled for the most recent kernels installed on your computer. If you are using proprietary drivers and you want to use an older kernel, you will need to remove the new one first.")


### PR DESCRIPTION
Because otherwise it's just confusing with both the kernel update itself (linux-meta source) and the linux-tools-common (linux source) update being listed as "The Linux Kernel". While not a sophisticated solution, neither is the aliasing in the first place, so this should effectively filter out dangling updates like the tools or similar.