### PR TITLE
Fix root refresh creating root owned files and on LMDE ignoring settings

### DIFF
--- a/etc/sudoers.d/mintupdate
+++ b/etc/sudoers.d/mintupdate
@@ -1,6 +1,7 @@
 # Allow any user to check for new system updates without
 # requiring user authentication.
 
+Defaults!/usr/lib/linuxmint/mintUpdate/checkAPT.py shell_noargs, !env_reset
 ALL ALL = NOPASSWD:/usr/lib/linuxmint/mintUpdate/checkAPT.py
 ALL ALL = NOPASSWD:/usr/lib/linuxmint/mintUpdate/synaptic-workaround.py
 ALL ALL = NOPASSWD:/usr/lib/linuxmint/mintUpdate/dpkg_lock_check.sh


### PR DESCRIPTION
Fixes https://github.com/linuxmint/mintupdate/issues/169
Fixes https://github.com/linuxmint/mintupdate/issues/259
Fixes https://github.com/linuxmint/lmde-3-cinnamon-beta/issues/50

Also gets you out of https://github.com/linuxmint/mintupdate/issues/379 I suppose but I'll leave that up to you - it's still a good idea to limit privilege elevation to the minimum regardless.