### PR TITLE
Prevent right-click blacklisting PRIORITY_UPDATES

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/Classes.py
+++ b/usr/lib/linuxmint/mintUpdate/Classes.py
@@ -5,6 +5,11 @@ gettext.install("mintupdate", "/usr/share/locale")
 import html
 from gi.repository import Gio
 
+
+# These updates take priority over other updates.
+# If a new version of these packages is available, nothing else is listed.
+PRIORITY_UPDATES = ['mintupdate', 'mint-upgrade-info']
+
 settings = Gio.Settings("com.linuxmint.updates")
 if settings.get_boolean("use-lowlatency-kernels"):
     CONFIGURED_KERNEL_TYPE = "-lowlatency"

--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -13,7 +13,7 @@ import traceback
 
 from gi.repository import Gio
 
-from Classes import Update, Alias, Rule, KERNEL_PKG_NAMES, CONFIGURED_KERNEL_TYPE
+from Classes import Update, Alias, Rule, KERNEL_PKG_NAMES, CONFIGURED_KERNEL_TYPE, PRIORITY_UPDATES
 
 gettext.install("mintupdate", "/usr/share/locale")
 
@@ -33,11 +33,6 @@ class KernelVersion():
         self.numeric_representation = ".".join(self.numeric_versions)
         self.std_version = "%s.%s.%s-%s" % (version_array[0], version_array[1], version_array[2], version_array[3])
         self.series = "%s.%s.%s" % (version_array[0], version_array[1], version_array[2])
-
-# These updates take priority over other updates.
-# If a new version of these packages is available,
-# nothing else is listed.
-PRIORITY_UPDATES = ['mintupdate', 'mint-upgrade-info']
 
 class APTCheck():
 

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -26,7 +26,7 @@ gi.require_version('AppIndicator3', '0.1')
 from gi.repository import Gtk, Gdk, GdkPixbuf, GdkX11, Gio, Pango
 from gi.repository import AppIndicator3 as AppIndicator
 
-from Classes import Update
+from Classes import Update, PRIORITY_UPDATES
 
 # import AUTOMATIONS dict
 with open("/usr/share/linuxmint/mintupdate/automation/index.json") as f:
@@ -1657,10 +1657,16 @@ class MintUpdate():
                 package_update = model.get_value(iter, UPDATE_OBJ)
                 menu = Gtk.Menu()
                 menuItem = Gtk.MenuItem.new_with_mnemonic(_("Ignore the current update for this package"))
-                menuItem.connect("activate", self.add_to_ignore_list, "%s=%s" % (package_update.source_name, package_update.new_version))
+                if package_update.source_name in PRIORITY_UPDATES:
+                    menuItem.set_sensitive(False)
+                else:
+                    menuItem.connect("activate", self.add_to_ignore_list, "%s=%s" % (package_update.source_name, package_update.new_version))
                 menu.append(menuItem)
                 menuItem = Gtk.MenuItem.new_with_mnemonic(_("Ignore all future updates for this package"))
-                menuItem.connect("activate", self.add_to_ignore_list, package_update.source_name)
+                if package_update.source_name in PRIORITY_UPDATES:
+                    menuItem.set_sensitive(False)
+                else:
+                    menuItem.connect("activate", self.add_to_ignore_list, package_update.source_name)
                 menu.append(menuItem)
                 menu.attach_to_widget (widget, None)
                 menu.show_all()


### PR DESCRIPTION
Mostly so new users don't accidentally do this via right-click. It's still possible to blacklist them manually in preferences.