### PR TITLE
Add simple reboot notification for kernel updates

### DIFF
--- a/usr/share/linuxmint/mintupdate/main.ui
+++ b/usr/share/linuxmint/mintupdate/main.ui
@@ -130,6 +130,7 @@
               <object class="GtkBox" id="hbox_infobar">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
                 </child>


### PR DESCRIPTION
This adds a non-removable infobar on every kernel image update. The option to hide the mintupdate window after updates are done gets overridden to make sure the infobar is seen (the alternative would have been a popup window).

This creates a common function to display infobars, all other infobar will be changed to use this in a related PR. Infobars will be changed to be able to show several at once, stacked vertically (also see yet another to be submitted PR).

Closes #451