### PR TITLE
Always show all applicable infobars, and all infobars to use show_infobar function

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -620,7 +620,7 @@ class RefreshThread(threading.Thread):
                     label3 = _("To switch to a different Linux Mint mirror and solve this problem, click OK.")
                     self.application.show_infobar(_("Please switch to another Linux Mint mirror"),
                         _("Your APT cache is corrupted."), Gtk.MessageType.ERROR,
-                        callback=_on_infobar_mintsources_response)
+                        callback=self._on_infobar_mintsources_response)
                     self.application.set_status(_("Could not refresh the list of updates"), "%s\n%s\n%s" % (label1, label2, label3), "mintupdate-error", True)
                     self.application.logger.write("Error: The APT policy is incorrect!")
                     self.application.stack.set_visible_child_name("status_error")


### PR DESCRIPTION
Infobars use a new common function introduced in #478. Furthermore, all applicable infobars will be shown at the same time to make sure important information is getting relayed rather than being hidden behind another infobar the user may have chosen to ignore. Example:

![screenshot at 2019-03-07 12-32-59](https://user-images.githubusercontent.com/13855078/53955719-01472a00-40da-11e9-9e6f-3a2ca79299fe.png)

Depends on #478