### PR TITLE
Fix kernel removal

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -208,7 +208,7 @@ class KernelRow(Gtk.ListBoxRow):
             if self.application.dpkg_locked():
                 self.application.show_dpkg_lock_msg(window)
             else:
-                thread = InstallKernelThread([[version, installed]], self.application)
+                thread = InstallKernelThread([[version, kernel_type, origin, installed]], self.application)
                 thread.start()
                 window.hide()
 


### PR DESCRIPTION
Seems f0829ac04b559a76fed0639bf5590f80bd78bd8d had caused a rebase issue in #434 (which reverted the former again) and this part got lost.