### PR TITLE
Fix generic blacklisting of kernel packages

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -1816,13 +1816,14 @@ class MintUpdate():
                 if package_update.source_name in PRIORITY_UPDATES:
                     menuItem.set_sensitive(False)
                 else:
-                    menuItem.connect("activate", self.add_to_ignore_list, "%s=%s" % (package_update.source_name, package_update.new_version))
+                    menuItem.connect("activate", self.add_to_ignore_list,
+                                     f"{package_update.real_source_name}={package_update.new_version}")
                 menu.append(menuItem)
                 menuItem = Gtk.MenuItem.new_with_mnemonic(_("Ignore all future updates for this package"))
                 if package_update.source_name in PRIORITY_UPDATES:
                     menuItem.set_sensitive(False)
                 else:
-                    menuItem.connect("activate", self.add_to_ignore_list, package_update.source_name)
+                    menuItem.connect("activate", self.add_to_ignore_list, package_update.real_source_name)
                 menu.append(menuItem)
                 menu.attach_to_widget (widget, None)
                 menu.show_all()


### PR DESCRIPTION
Currently it is impossible to blacklist kernels for all future updates because of the source name rewriting we are doing for cosmetic reasons. This fixes that by making the blacklist always use the unmodified source name. 

The only downside is that if a user was to rely on the modified source name as shown in the listing and then try to manually blacklist a kernel package based on that displayed name then it wouldn't work for them. 

