### PR TITLE
Split APT cache refresh away from checkAPT

### DIFF
--- a/etc/sudoers.d/mintupdate
+++ b/etc/sudoers.d/mintupdate
@@ -1,6 +1,6 @@
 # Allow any user to check for new system updates without
 # requiring user authentication.
 
-ALL ALL = NOPASSWD:/usr/lib/linuxmint/mintUpdate/checkAPT.py
+ALL ALL = NOPASSWD:/usr/bin/mint-refresh-cache
 ALL ALL = NOPASSWD:/usr/lib/linuxmint/mintUpdate/synaptic-workaround.py
 ALL ALL = NOPASSWD:/usr/lib/linuxmint/mintUpdate/dpkg_lock_check.sh

--- a/usr/bin/mint-refresh-cache
+++ b/usr/bin/mint-refresh-cache
@@ -1,0 +1,18 @@
+#!/usr/bin/python3
+import apt
+import os
+import sys
+
+if __name__ == "__main__":
+    if os.getuid() == 0:
+        if "--use-synaptic" in sys.argv:
+            window_id = int(sys.argv[2])
+            from subprocess import Popen
+            cmd = ["sudo", "/usr/sbin/synaptic", "--hide-main-window", "--update-at-startup", "--non-interactive", "--parent-window-id", "%d" % window_id]
+            comnd = Popen(' '.join(cmd), shell=True)
+            comnd.wait()
+        else:
+            cache = apt.Cache()
+            cache.update()
+    else:
+        print("Error: mint-refresh-cache requires admin priviledges")

--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -50,20 +50,7 @@ class APTCheck():
                             alias_package = alias_package.strip()
                             self.aliases[alias_package] = alias_object
 
-    def refresh_cache(self):
-        if os.getuid() == 0 :
-            if "--use-synaptic" in sys.argv:
-                window_id = int(sys.argv[2])
-                from subprocess import Popen
-                cmd = ["sudo", "/usr/sbin/synaptic", "--hide-main-window", "--update-at-startup", "--non-interactive", "--parent-window-id", "%d" % window_id]
-                comnd = Popen(' '.join(cmd), shell=True)
-                comnd.wait()
-            else:
-                self.cache.update()
-
     def find_changes(self):
-        # Reopen the cache to reflect any updates
-        self.cache.open(None)
         self.cache.upgrade(self.settings.get_boolean("dist-upgrade"))
         changes = self.cache.get_changes()
 
@@ -360,7 +347,6 @@ class APTCheck():
 if __name__ == "__main__":
     try:
         check = APTCheck()
-        check.refresh_cache()
         check.find_changes()
         check.apply_l10n_descriptions()
         check.load_aliases()

--- a/usr/lib/linuxmint/mintUpdate/mintupdate-cli.py
+++ b/usr/lib/linuxmint/mintUpdate/mintupdate-cli.py
@@ -32,9 +32,9 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     try:
-        check = APTCheck()
         if args.refresh_cache:
-            check.refresh_cache()
+            subprocess.run("sudo /usr/bin/mint-refresh-cache", shell=True)
+        check = APTCheck()
         check.find_changes()
 
         blacklisted = []


### PR DESCRIPTION
Refreshing the cache needs elevated priviledges, finding the list of updates
doesn't. We want to use dconf and all without root priviledges as much as possible.