### PR TITLE
Blacklisting: Add user blacklist export button to preferences,

### DIFF
--- a/doc/man/mintupdate-cli.8
+++ b/doc/man/mintupdate-cli.8
@@ -42,9 +42,11 @@ Only include kernel updates
 Only include security updates
 .TP
 \fB-i IGNORE\fR, \fB--ignore IGNORE\fR
-List of updates to ignore (comma-separated).
+List of updates to ignore (comma-separated list of source package names).
 
-Note: You can also blacklist updates by adding their name to /etc/mintupdate.blacklist.
+Note: You can also blacklist updates by adding them to /etc/mintupdate.blacklist, one source package per line.
+
+To ignore a specific version, use the format package=version.
 .TP
 \fB-r\fR, \fB--refresh-cache\fR
 Refresh the APT cache

--- a/usr/bin/mintupdate-automation
+++ b/usr/bin/mintupdate-automation
@@ -10,7 +10,7 @@ if not os.getuid() == 0:
     print("This command needs to be run as root or with sudo.")
     sys.exit(1)
 
-if len(sys.argv) != 3 or sys.argv[1] not in ("upgrade", "autoremove") or sys.argv[2] not in ("enable", "disable"):
+if len(sys.argv) != 3 or sys.argv[1] not in ("upgrade", "autoremove", "blacklist") or sys.argv[2] not in ("enable", "disable"):
     print("Bad arguments")
     sys.exit(1)
 
@@ -22,15 +22,17 @@ automation_id = sys.argv[1]
 
 def do_enable(_automation_id):
     (filename, name) = AUTOMATIONS[_automation_id]
-    if not os.path.isfile(filename):
+    if not os.path.isfile(filename) or sys.argv[1] == "blacklist":
         if name == "systemd":
             basename = os.path.basename(filename)
             subprocess.run(["/bin/systemctl", "start", basename])
             subprocess.run(["/bin/systemctl", "enable", basename])
         else:
-            default = "/usr/share/linuxmint/mintupdate/automation/%s.default" % automation_id
-            os.system("cp %s %s" % (default, filename))
-            print("%s %s created." % (name, filename))
+            default = f"/usr/share/linuxmint/mintupdate/automation/{_automation_id}.default"
+            os.system(f"cp {default} {filename}")
+            print(f"{name} {filename} created.")
+            if sys.argv[1] == "blacklist":
+                add_user_blacklist(filename)
 
 def do_disable(_automation_id):
     (filename, name) = AUTOMATIONS[_automation_id]
@@ -40,8 +42,21 @@ def do_disable(_automation_id):
             subprocess.run(["/bin/systemctl", "stop", basename])
             subprocess.run(["/bin/systemctl", "disable", basename])
         else:
-            os.system("rm -f %s" % filename)
-            print("%s %s removed." % (name, filename))
+            os.system(f"rm -f {filename}")
+            print(f"{name} {filename} removed.")
+
+def add_user_blacklist(outfile):
+    import tempfile
+    try:
+        infile = os.path.join(tempfile.gettempdir(), "mintUpdate/blacklist")
+        with open(infile, "r") as export:
+            with open(outfile, "a") as f:
+                for line in export:
+                    f.write(line)
+        os.remove(infile)
+        print("User blacklist exported.")
+    except:
+        pass
 
 if sys.argv[2] == "enable":
     do_enable(automation_id)

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -2080,6 +2080,7 @@ class MintUpdate():
         builder.get_object("button_remove").connect("clicked", self.remove_blacklisted_package, treeview_blacklist)
         builder.get_object("button_add").set_always_show_image(True)
         builder.get_object("button_remove").set_always_show_image(True)
+        builder.get_object("export_blacklist_button").connect("clicked", self.export_blacklist)
         self.preferences_window_showing = True
 
         window.show_all()
@@ -2087,6 +2088,13 @@ class MintUpdate():
 
     def on_refresh_schedule_toggled(self, widget, builder):
         builder.get_object("refresh_grid").set_visible(widget.get_active())
+
+    def export_blacklist(self, widget):
+        filename = os.path.join(tempfile.gettempdir(), "mintUpdate/blacklist")
+        blacklist = self.settings.get_strv("blacklisted-packages")
+        with open(filename, "w") as f:
+            f.write("\n".join(blacklist) + "\n")
+        subprocess.run(["pkexec", "/usr/bin/mintupdate-automation", "blacklist", "enable"])
 
     @staticmethod
     def set_automation(automation_id, builder):
@@ -2098,7 +2106,7 @@ class MintUpdate():
         elif not active and exists:
             action = "disable"
         if action:
-            subprocess.call(["pkexec", "/usr/bin/mintupdate-automation", automation_id, action])
+            subprocess.run(["pkexec", "/usr/bin/mintupdate-automation", automation_id, action])
 
     def save_preferences(self, widget, builder):
         self.settings.set_boolean('hide-window-after-update', builder.get_object("checkbutton_hide_window_after_update").get_active())

--- a/usr/share/linuxmint/mintupdate/preferences.ui
+++ b/usr/share/linuxmint/mintupdate/preferences.ui
@@ -401,7 +401,7 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="export_blacklist_button">
-                    <property name="label" translatable="yes">Export your blacklist to /etc/mintupdate.blacklist</property>
+                    <property name="label" translatable="yes">Export blacklist to /etc/mintupdate.blacklist</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>

--- a/usr/share/linuxmint/mintupdate/preferences.ui
+++ b/usr/share/linuxmint/mintupdate/preferences.ui
@@ -339,12 +339,6 @@
                             <property name="position">0</property>
                           </packing>
                         </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -406,6 +400,21 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkButton" id="export_blacklist_button">
+                    <property name="label" translatable="yes">Export your blacklist to /etc/mintupdate.blacklist</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="halign">start</property>
+                    <property name="margin_left">24</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">5</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -421,7 +430,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">5</property>
+                    <property name="position">6</property>
                   </packing>
                 </child>
                 <child>
@@ -437,7 +446,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">6</property>
+                    <property name="position">7</property>
                   </packing>
                 </child>
               </object>


### PR DESCRIPTION
- fix mintupdate-cli to use the same blacklist features as mintupdate
(wildcard support, version support),
- fix typo in mintupdate-automations leading to bad blacklist template
creation,
- update documentation,
- finally remove unnecessary import and variable in mintupdate-cli (actually the entire try..except seems quite unnecessary but I left it in)

Fixes #372 