### PR TITLE
CacheWatcher pause/resume changes in interaction with refresh and install threads

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -32,6 +32,7 @@ class InstallKernelThread(threading.Thread):
     def run(self):
         self.application.window.set_sensitive(False)
         do_regular = False
+        self.application.cache_watcher.pause()
         for (version, kernel_type, origin, remove) in self.kernels:
             if not do_regular:
                 do_regular = True
@@ -98,6 +99,7 @@ class InstallKernelThread(threading.Thread):
             subprocess.run(cmd, stdout=self.application.logger.log, stderr=self.application.logger.log)
             subprocess.run(["sudo","/usr/lib/linuxmint/mintUpdate/synaptic-workaround.py","disable"])
             f.close()
+        self.application.refresh()
         self.cache = None
         self.application.window.set_sensitive(True)
 

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -632,6 +632,9 @@ class RefreshThread(threading.Thread):
         self.root_mode = root_mode
         self.application = application
 
+    def __del__(self):
+        self.application.cache_watcher.resume()
+
     def check_policy(self):
         # Check the presence of the Mint layer
         p = subprocess.run(['apt-cache', 'policy'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -992,7 +995,6 @@ class RefreshThread(threading.Thread):
                                               callback=infobar_callback)
 
             Gdk.threads_leave()
-            self.application.cache_watcher.resume()
 
         except:
             traceback.print_exc()

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -110,10 +110,11 @@ class CacheWatcher(threading.Thread):
                     pass
             time.sleep(self.refresh_frequency)
 
-    def resume(self):
+    def resume(self, update_cachetime=True):
         if not self.pkgcache:
             return
-        self.update_cachetime()
+        if update_cachetime:
+            self.update_cachetime()
         self.paused = False
 
     def pause(self):

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -406,7 +406,11 @@ class InstallThread(threading.Thread):
         self.application.window.set_sensitive(False)
         self.reboot_required = self.application.reboot_required
 
+    def __del__(self):
+        self.application.cache_watcher.resume(False)
+
     def run(self):
+        self.application.cache_watcher.pause()
         try:
             self.application.logger.write("Install requested by user")
             Gdk.threads_enter()

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -111,7 +111,7 @@ class CacheWatcher(threading.Thread):
             time.sleep(self.refresh_frequency)
 
     def resume(self, update_cachetime=True):
-        if not self.pkgcache:
+        if not self.paused or not self.pkgcache:
             return
         if update_cachetime:
             self.update_cachetime()


### PR DESCRIPTION
Ran into an instance where the cache got flushed during an install instead of at the end of it, which usually doesn't happen. This must be rare because it never happened in all my testing so far, or maybe the apt update today is responsible. 

Either way, these changes will explicitly pause CacheWatcher at the start of all refresh and install threads and resume at the end. The stored cache time only gets updated where applicable. 