### PR TITLE
Kernel window: Greatly speed up load times

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/checkKernels.py
+++ b/usr/lib/linuxmint/mintUpdate/checkKernels.py
@@ -14,13 +14,14 @@ try:
     signed_kernels = ['']
     local_kernels = {}
     r = re.compile(r'^(?:linux-image-)(?:unsigned-)?(\d.+?)(%s)$' % "|".join(SUPPORTED_KERNEL_TYPES))
-    for pkg in cache:
+    for pkg_name in cache.keys():
         installed = 0
         used = 0
         installable = 0
         pkg_version = ""
-        pkg_match = r.match(pkg.name)
+        pkg_match = r.match(pkg_name)
         if pkg_match:
+            pkg = cache[pkg_name]
             pkg_data = None
             if pkg.candidate:
                 pkg_data = pkg.candidate


### PR DESCRIPTION
By iterating only over the keys instead of the entire objects a lot of execution time can be saved (runs about twice as fast on my system).