### PR TITLE
Kernel window: Add support for queueing actions

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -222,13 +222,13 @@ class KernelRow(Gtk.ListBoxRow):
         queuebutton.connect("clicked", self.queue_kernel, kernel)
         if installed:
             button.set_label(_("Remove"))
-            queuebutton.set_label(_("Queue removal"))
+            queuebutton.set_label(_("Queue Removal"))
             if used:
                 button.set_tooltip_text(_("This kernel cannot be removed because it is currently in use."))
                 button.set_sensitive(False)
         else:
             button.set_label(_("Install"))
-            queuebutton.set_label(_("Queue installation"))
+            queuebutton.set_label(_("Queue Installation"))
             if not installable:
                 button.set_tooltip_text(_("This kernel is not installable."))
                 button.set_sensitive(False)
@@ -558,7 +558,7 @@ class KernelWindow():
             self.confirmation_listbox.remove(child)
         for item in kernel_list:
             self.confirmation_listbox.add(item)
-        self.confirmation_dialog.set_title(widget.get_label())
+        self.confirmation_dialog.set_title(widget.get_label()[:-1])
         self.confirmation_dialog.show_all()
 
     def on_cancel_clicked(self, widget, *args):

--- a/usr/share/linuxmint/mintupdate/kernels.ui
+++ b/usr/share/linuxmint/mintupdate/kernels.ui
@@ -586,6 +586,7 @@
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
                         <property name="border_width">6</property>
+                        <property name="selection_mode">none</property>
                       </object>
                     </child>
                   </object>

--- a/usr/share/linuxmint/mintupdate/kernels.ui
+++ b/usr/share/linuxmint/mintupdate/kernels.ui
@@ -231,11 +231,10 @@
             <property name="spacing">6</property>
             <child>
               <object class="GtkButton" id="button_help">
-                <property name="label">gtk-help</property>
+                <property name="label" translatable="yes">Help</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -245,11 +244,10 @@
             </child>
             <child>
               <object class="GtkButton" id="button_continue">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">Continue</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
                 <style>
                   <class name="text-button"/>
                 </style>
@@ -448,11 +446,10 @@
             </child>
             <child>
               <object class="GtkButton" id="button_close">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -516,12 +513,11 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="b_confirmation_cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">Cancel</property>
                 <property name="name">b_cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -531,12 +527,11 @@
             </child>
             <child>
               <object class="GtkButton" id="b_confirmation_confirm">
-                <property name="label">gtk-apply</property>
+                <property name="label" translatable="yes">Apply</property>
                 <property name="name">b_remove</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/usr/share/linuxmint/mintupdate/kernels.ui
+++ b/usr/share/linuxmint/mintupdate/kernels.ui
@@ -214,12 +214,12 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="xalign">0.029999999329447746</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
+            <property name="padding">3</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -231,10 +231,11 @@
             <property name="spacing">6</property>
             <child>
               <object class="GtkButton" id="button_help">
-                <property name="label" translatable="yes">Help</property>
+                <property name="label">gtk-help</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -244,10 +245,11 @@
             </child>
             <child>
               <object class="GtkButton" id="button_continue">
-                <property name="label" translatable="yes">Continue</property>
+                <property name="label">gtk-ok</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
                 <style>
                   <class name="text-button"/>
                 </style>
@@ -415,9 +417,25 @@
             <property name="spacing">6</property>
             <property name="layout_style">end</property>
             <child>
-              <object class="GtkButton" id="button_massremove">
-                <property name="label" translatable="yes">Remove old kernels...</property>
+              <object class="GtkButton" id="button_do_queue">
+                <property name="label" translatable="yes">Perform queued actions</property>
                 <property name="visible">True</property>
+                <property name="sensitive">False</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+                <property name="non_homogeneous">True</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_massremove">
+                <property name="label" translatable="yes">Remove kernels</property>
+                <property name="visible">True</property>
+                <property name="sensitive">False</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
               </object>
@@ -425,19 +443,22 @@
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">2</property>
+                <property name="non_homogeneous">True</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="button_close">
-                <property name="label" translatable="yes">Close</property>
+                <property name="label">gtk-close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">3</property>
+                <property name="non_homogeneous">True</property>
               </packing>
             </child>
           </object>
@@ -445,6 +466,7 @@
             <property name="expand">False</property>
             <property name="fill">False</property>
             <property name="position">1</property>
+            <property name="non_homogeneous">True</property>
           </packing>
         </child>
       </object>
@@ -461,6 +483,7 @@
     <property name="default_width">800</property>
     <property name="default_height">500</property>
     <property name="icon_name">mintupdate</property>
+    <property name="urgency_hint">True</property>
     <child type="titlebar">
       <placeholder/>
     </child>
@@ -471,8 +494,8 @@
   <object class="GtkDialog" id="confirmation_window">
     <property name="can_focus">False</property>
     <property name="border_width">6</property>
-    <property name="title" translatable="yes">Remove old kernels...</property>
     <property name="modal">True</property>
+    <property name="default_width">350</property>
     <property name="type_hint">dialog</property>
     <property name="deletable">False</property>
     <property name="transient_for">window1</property>
@@ -488,31 +511,35 @@
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="button_box">
             <property name="can_focus">False</property>
+            <property name="halign">center</property>
+            <property name="hexpand">True</property>
             <property name="layout_style">end</property>
             <child>
-              <object class="GtkButton" id="b_cancel">
-                <property name="label" translatable="yes">Cancel</property>
+              <object class="GtkButton" id="b_confirmation_cancel">
+                <property name="label">gtk-cancel</property>
                 <property name="name">b_cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
               </object>
               <packing>
-                <property name="expand">True</property>
+                <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="b_remove">
-                <property name="label" translatable="yes">Remove selected kernels</property>
+              <object class="GtkButton" id="b_confirmation_confirm">
+                <property name="label">gtk-apply</property>
                 <property name="name">b_remove</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
+                <property name="use_stock">True</property>
               </object>
               <packing>
-                <property name="expand">True</property>
+                <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
@@ -525,11 +552,12 @@
           </packing>
         </child>
         <child>
-          <object class="GtkLabel">
+          <object class="GtkLabel" id="confirmation_label">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="margin_left">20</property>
-            <property name="label" translatable="yes">Select the kernels you want to remove:</property>
+            <property name="margin_right">20</property>
+            <property name="label" translatable="yes">Please confirm the following actions:</property>
             <property name="wrap">True</property>
             <property name="xalign">0</property>
           </object>
@@ -558,16 +586,11 @@
                     <property name="hexpand">True</property>
                     <property name="vexpand">True</property>
                     <child>
-                      <object class="GtkBox" id="box_list">
+                      <object class="GtkListBox" id="confirmation_listbox">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
                         <property name="border_width">6</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <placeholder/>
-                        </child>
                       </object>
                     </child>
                   </object>

--- a/usr/share/linuxmint/mintupdate/kernels.ui
+++ b/usr/share/linuxmint/mintupdate/kernels.ui
@@ -416,7 +416,7 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button_do_queue">
-                <property name="label" translatable="yes">Perform queued actions</property>
+                <property name="label" translatable="yes">Perform Queued Actions…</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">True</property>
@@ -431,7 +431,7 @@
             </child>
             <child>
               <object class="GtkButton" id="button_massremove">
-                <property name="label" translatable="yes">Remove kernels</property>
+                <property name="label" translatable="yes">Remove Kernels…</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">True</property>


### PR DESCRIPTION
Adds a second button to each kernel row to queue the action:
![mintupdate-queue](https://user-images.githubusercontent.com/13855078/54907897-f4527500-4ee6-11e9-9b1e-f58cf1901d71.png)
After clicking the _Perform queued actions_ button the user gets to confirm each action before applying the selected ones:
![mintupdate-queue-confirmation](https://user-images.githubusercontent.com/13855078/54907911-fa485600-4ee6-11e9-8488-cc2cbc124f35.png)
This uses the same confirmation window as previously the Remove kernels button, which looks the same now (except for the title). 

Related changes:
- Pressing Escape with the confirmation window open no longer locks up the application
- Remove old kernels... button is now called Remove kernels
- The buttons in the bottom row that pop up the confirmation dialogs are only enabled where applicable
- Some structural code changes by introducing a Kernel() class to simplify moving around the data needed to install/remove a kernel