### PR TITLE
Change all applicable buttons to Gtk stock buttons

### DIFF
--- a/usr/share/linuxmint/mintupdate/history.ui
+++ b/usr/share/linuxmint/mintupdate/history.ui
@@ -50,10 +50,11 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button_close">
-                <property name="label" translatable="yes">Close</property>
+                <property name="label">gtk-close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/usr/share/linuxmint/mintupdate/information.ui
+++ b/usr/share/linuxmint/mintupdate/information.ui
@@ -132,11 +132,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="close_button">
-                <property name="label" translatable="yes">Close</property>
+                <property name="label">gtk-close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/usr/share/linuxmint/mintupdate/main.ui
+++ b/usr/share/linuxmint/mintupdate/main.ui
@@ -832,11 +832,12 @@
         <property name="baseline_position">top</property>
         <child>
           <object class="GtkButton" id="button_welcome_help">
-            <property name="label" translatable="yes">Help</property>
+            <property name="label">gtk-help</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="can_default">True</property>
             <property name="receives_default">True</property>
+            <property name="use_stock">True</property>
             <property name="always_show_image">True</property>
           </object>
           <packing>
@@ -847,11 +848,12 @@
         </child>
         <child>
           <object class="GtkButton" id="button_welcome_finish">
-            <property name="label" translatable="yes">OK</property>
+            <property name="label">gtk-ok</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="can_default">True</property>
             <property name="receives_default">True</property>
+            <property name="use_stock">True</property>
             <property name="always_show_image">True</property>
           </object>
           <packing>

--- a/usr/share/linuxmint/mintupdate/preferences.ui
+++ b/usr/share/linuxmint/mintupdate/preferences.ui
@@ -87,12 +87,14 @@
               <object class="GtkBox" id="box5">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="spacing">4</property>
                 <child>
                   <object class="GtkButton" id="button_remove">
+                    <property name="label">gtk-remove</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="image">image6</property>
+                    <property name="use_stock">True</property>
                     <property name="always_show_image">True</property>
                   </object>
                   <packing>
@@ -104,10 +106,11 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="button_add">
+                    <property name="label">gtk-add</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="image">image7</property>
+                    <property name="use_stock">True</property>
                     <property name="always_show_image">True</property>
                   </object>
                   <packing>
@@ -217,10 +220,11 @@
             <property name="spacing">6</property>
             <child>
               <object class="GtkButton" id="pref_button_apply">
-                <property name="label" translatable="yes">Apply</property>
+                <property name="label">gtk-apply</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -231,10 +235,11 @@
             </child>
             <child>
               <object class="GtkButton" id="pref_button_cancel">
-                <property name="label" translatable="yes">Cancel</property>
+                <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/usr/share/linuxmint/mintupdate/preferences.ui
+++ b/usr/share/linuxmint/mintupdate/preferences.ui
@@ -32,18 +32,6 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
-  <object class="GtkImage" id="image6">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">list-remove-symbolic</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image7">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">list-add-symbolic</property>
-    <property name="icon_size">1</property>
-  </object>
   <object class="GtkBox" id="page_blacklist">
     <property name="visible">True</property>
     <property name="can_focus">False</property>


### PR DESCRIPTION
Covers all windows except for the kernel window, that's handled in a separate PR.

Because using stock buttons simply makes sense. For the blacklist tab in Preferences it has the further advantage (in my opinion) of adding a text label to the buttons.