### PR TITLE
Kernel window: Ellipsis handling

### DIFF
--- a/makepot
+++ b/makepot
@@ -6,5 +6,5 @@ intltool-extract --type=gettext/glade usr/share/linuxmint/mintupdate/main.ui
 intltool-extract --type=gettext/glade usr/share/linuxmint/mintupdate/preferences.ui
 intltool-extract --type=gettext/glade usr/share/linuxmint/mintupdate/shortcuts.ui
 xml2po -o mintupdate.pot -m mallard usr/share/help/C/mintupdate/*.page
-xgettext --language=Python --from-code=utf-8 --keyword=_ --keyword=N_ --output=mintupdate.pot --join-existing usr/lib/linuxmint/mintUpdate/*.py generate_desktop_files usr/bin/mintupdate-cli usr/bin/mint-release-upgrade usr/bin/mint-release-upgrade-root usr/lib/linuxmint/mintUpdate/aliases usr/share/linuxmint/mintupdate/*.ui.h
+xgettext --language=Python --keyword=_ --keyword=N_ --output=mintupdate.pot --join-existing usr/lib/linuxmint/mintUpdate/*.py generate_desktop_files usr/bin/mintupdate-cli usr/bin/mint-release-upgrade usr/bin/mint-release-upgrade-root usr/lib/linuxmint/mintUpdate/aliases usr/share/linuxmint/mintupdate/*.ui.h
 rm -f usr/share/linuxmint/mintupdate/*.ui.h

--- a/makepot
+++ b/makepot
@@ -6,5 +6,5 @@ intltool-extract --type=gettext/glade usr/share/linuxmint/mintupdate/main.ui
 intltool-extract --type=gettext/glade usr/share/linuxmint/mintupdate/preferences.ui
 intltool-extract --type=gettext/glade usr/share/linuxmint/mintupdate/shortcuts.ui
 xml2po -o mintupdate.pot -m mallard usr/share/help/C/mintupdate/*.page
-xgettext --language=Python --keyword=_ --keyword=N_ --output=mintupdate.pot --join-existing usr/lib/linuxmint/mintUpdate/*.py generate_desktop_files usr/bin/mintupdate-cli usr/bin/mint-release-upgrade usr/bin/mint-release-upgrade-root usr/lib/linuxmint/mintUpdate/aliases usr/share/linuxmint/mintupdate/*.ui.h
+xgettext --language=Python --from-code=utf-8 --keyword=_ --keyword=N_ --output=mintupdate.pot --join-existing usr/lib/linuxmint/mintUpdate/*.py generate_desktop_files usr/bin/mintupdate-cli usr/bin/mint-release-upgrade usr/bin/mint-release-upgrade-root usr/lib/linuxmint/mintUpdate/aliases usr/share/linuxmint/mintupdate/*.ui.h
 rm -f usr/share/linuxmint/mintupdate/*.ui.h

--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -324,8 +324,10 @@ class KernelWindow():
         self.queued_kernels_listbox = []
         self.queued_kernels = []
         self.button_massremove = self.builder.get_object("button_massremove")
+        self.button_massremove.set_label = _("Remove Kernels") + chr(0x2026)
         self.button_massremove.connect("clicked", self.show_confirmation_dialog, self.remove_kernels_listbox)
         self.button_do_queue = self.builder.get_object("button_do_queue")
+        self.button_do_queue.set_label = _("Perform Queued Actions") + chr(0x2026)
         self.button_do_queue.connect("clicked", self.show_confirmation_dialog, self.queued_kernels_listbox)
 
         # Get distro release dates for support duration calculation

--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
 import apt
 import subprocess
 import os
@@ -324,11 +326,9 @@ class KernelWindow():
         self.queued_kernels_listbox = []
         self.queued_kernels = []
         self.button_massremove = self.builder.get_object("button_massremove")
-        self.button_massremove.set_label = _("Remove Kernels") + chr(0x2026)
-        self.button_massremove.connect("clicked", self.show_confirmation_dialog, self.remove_kernels_listbox)
+        self.button_massremove.connect("clicked", self.show_confirmation_dialog, _("Remove Kernels"), self.remove_kernels_listbox)
         self.button_do_queue = self.builder.get_object("button_do_queue")
-        self.button_do_queue.set_label = _("Perform Queued Actions") + chr(0x2026)
-        self.button_do_queue.connect("clicked", self.show_confirmation_dialog, self.queued_kernels_listbox)
+        self.button_do_queue.connect("clicked", self.show_confirmation_dialog, _("Perform Queued Actions"), self.queued_kernels_listbox)
 
         # Get distro release dates for support duration calculation
         self.release_dates = get_release_dates()
@@ -560,13 +560,13 @@ class KernelWindow():
     def show_help(self, widget):
         os.system("yelp help:mintupdate/index &")
 
-    def show_confirmation_dialog(self, widget, kernel_list):
+    def show_confirmation_dialog(self, widget, title, kernel_list):
         self.window.set_sensitive(False)
         for child in self.confirmation_listbox.get_children():
             self.confirmation_listbox.remove(child)
         for item in kernel_list:
             self.confirmation_listbox.add(item)
-        self.confirmation_dialog.set_title(widget.get_label()[:-1])
+        self.confirmation_dialog.set_title(title)
         self.confirmation_dialog.show_all()
 
     def on_cancel_clicked(self, widget, *args):

--- a/usr/share/linuxmint/mintupdate/kernels.ui
+++ b/usr/share/linuxmint/mintupdate/kernels.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="3.10"/>
+  <requires lib="gtk+" version="3.18"/>
   <object class="GtkBox" id="intro_box">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -416,7 +416,7 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button_do_queue">
-                <property name="label" translatable="yes">Perform Queued Actions…</property>
+                <property name="label" translatable="yes">Perform Queued Actions</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">True</property>
@@ -431,7 +431,7 @@
             </child>
             <child>
               <object class="GtkButton" id="button_massremove">
-                <property name="label" translatable="yes">Remove Kernels…</property>
+                <property name="label" translatable="yes">Remove Kernels</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">True</property>

--- a/usr/share/linuxmint/mintupdate/kernels.ui
+++ b/usr/share/linuxmint/mintupdate/kernels.ui
@@ -416,7 +416,7 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button_do_queue">
-                <property name="label" translatable="yes">Perform Queued Actions</property>
+                <property name="label" translatable="yes">Perform Queued Actions…</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">True</property>
@@ -431,7 +431,7 @@
             </child>
             <child>
               <object class="GtkButton" id="button_massremove">
-                <property name="label" translatable="yes">Remove Kernels</property>
+                <property name="label" translatable="yes">Remove Kernels…</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">True</property>

--- a/usr/share/linuxmint/mintupdate/kernels.ui
+++ b/usr/share/linuxmint/mintupdate/kernels.ui
@@ -416,7 +416,7 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button_do_queue">
-                <property name="label" translatable="yes">Perform Queued Actions…</property>
+                <property name="label" translatable="yes">Perform Queued Actions...</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">True</property>
@@ -431,7 +431,7 @@
             </child>
             <child>
               <object class="GtkButton" id="button_massremove">
-                <property name="label" translatable="yes">Remove Kernels…</property>
+                <property name="label" translatable="yes">Remove Kernels...</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">True</property>


### PR DESCRIPTION
~I'd rather move this out of the translatable string so translators don't mess with it, I'm relying on it being the last character of the string for the window title.~
As discussed, ellipsis remains in the button msgid but the title gets a separate msgid without it. 

makepot had to be updated to support utf-8 characters.