### PR TITLE
Drop checkbutton_default_repo_is_ok

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -2082,7 +2082,6 @@ class MintUpdate():
 
         builder.get_object("checkbutton_hide_window_after_update").set_active(self.settings.get_boolean("hide-window-after-update"))
         builder.get_object("checkbutton_hide_systray").set_active(self.settings.get_boolean("hide-systray"))
-        builder.get_object("checkbutton_default_repo_is_ok").set_active(self.settings.get_boolean("default-repo-is-ok"))
         builder.get_object("checkbutton_warning_timeshift").set_active(self.settings.get_boolean("warn-about-timeshift"))
         builder.get_object("auto_upgrade_checkbox").set_active(os.path.isfile(AUTOMATIONS["upgrade"][0]))
         builder.get_object("auto_autoremove_checkbox").set_active(os.path.isfile(AUTOMATIONS["autoremove"][0]))
@@ -2157,7 +2156,6 @@ class MintUpdate():
     def save_preferences(self, widget, builder):
         self.settings.set_boolean('hide-window-after-update', builder.get_object("checkbutton_hide_window_after_update").get_active())
         self.settings.set_boolean('hide-systray', builder.get_object("checkbutton_hide_systray").get_active())
-        self.settings.set_boolean('default-repo-is-ok', builder.get_object("checkbutton_default_repo_is_ok").get_active())
         self.settings.set_boolean('warn-about-timeshift', builder.get_object("checkbutton_warning_timeshift").get_active())
         self.settings.set_int('refresh-days', int(builder.get_object("refresh_days").get_value()))
         self.settings.set_int('refresh-hours', int(builder.get_object("refresh_hours").get_value()))

--- a/usr/share/linuxmint/mintupdate/preferences.ui
+++ b/usr/share/linuxmint/mintupdate/preferences.ui
@@ -610,22 +610,6 @@
               </packing>
             </child>
             <child>
-              <object class="GtkCheckButton" id="checkbutton_default_repo_is_ok">
-                <property name="label" translatable="yes">Don't suggest switching to a local mirror</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="halign">start</property>
-                <property name="margin_left">24</property>
-                <property name="draw_indicator">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">4</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>


### PR DESCRIPTION
It became redundant following the change in https://github.com/linuxmint/mintupdate/commit/dfbcb0ae32f99f37521da334d45fa7406fcf2098.