### PR TITLE
KernelVersion rework

### DIFF
--- a/tests/test_kernel_window.py
+++ b/tests/test_kernel_window.py
@@ -21,8 +21,8 @@ def test_kernel_version_series_comparison():
     version1 = KernelVersion ("4.8.0-2-generic")
     version2 = KernelVersion ("4.15.0-43-generic")
     version3 = KernelVersion ("4.15.0-44-generic")
-    assert version1.numeric_versions < version2.numeric_versions
-    assert version2.numeric_versions < version3.numeric_versions
+    assert version1.version_id < version2.version_id
+    assert version2.version_id < version3.version_id
     assert version1.series < version2.series
     assert version2.series == version3.series
 

--- a/usr/lib/linuxmint/mintUpdate/Classes.py
+++ b/usr/lib/linuxmint/mintUpdate/Classes.py
@@ -46,6 +46,33 @@ def get_release_dates():
                 pass
     return release_dates
 
+class KernelVersion():
+
+    def __init__(self, version):
+        field_length = 3
+        self.version = version
+        self.version_id = []
+        version_id = self.version.replace("-", ".").split(".")
+        # Check if mainline rc kernel to ensure proper sorting vs mainline release kernels
+        suffix = next((x for x in version_id if x.startswith("rc")), None)
+        if not suffix:
+            suffix = "z"
+        # Copy numeric parts from version_id to self.version_id and fill up to field_length
+        for element in version_id:
+            if element.isnumeric():
+                self.version_id.append("0" * (field_length - len(element)) + element)
+        # Installed kernels always have len(self.version_id) >= 4 at this point,
+        # create missing parts for not installed mainline kernels:
+        while len(self.version_id) < 3:
+            self.version_id.append("0" * field_length)
+        if len(self.version_id) == 3:
+            self.version_id.append(f"{''.join((x[:field_length - 2].lstrip('0') + x[field_length - 2:] for x in self.version_id))}{suffix}")
+        elif len(self.version_id[3]) == 6:
+            # installed release mainline kernel, add suffix for sorting
+            self.version_id[3] += suffix
+        self.series = tuple(self.version_id[:3])
+        self.shortseries = tuple(self.version_id[:2])
+
 class Update():
 
     def __init__(self, package=None, input_string=None, source_name=None):

--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -13,22 +13,11 @@ import apt
 from gi.repository import Gio
 
 from Classes import (CONFIGURED_KERNEL_TYPE, KERNEL_PKG_NAMES,
-                     PRIORITY_UPDATES, Alias, Update)
+                     PRIORITY_UPDATES, Alias, KernelVersion, Update)
 
 gettext.install("mintupdate", "/usr/share/locale")
 
 meta_names = []
-
-class KernelVersion():
-
-    def __init__(self, version):
-        self.version = version
-        self.numeric_versions = self.version.replace("-", ".").split(".")
-        for i, element in enumerate(self.numeric_versions):
-            self.numeric_versions[i] = "0" * (3 - len(element)) + element
-        while len(self.numeric_versions) < 4:
-            self.numeric_versions.append("0" * 3)
-        self.series = tuple(self.numeric_versions[:3])
 
 class APTCheck():
 
@@ -109,14 +98,14 @@ class APTCheck():
                         # than any current candidate
                         if active_kernel.series == meta_kernel.series:
                             # same series
-                            if (not meta_candidate_same_series or meta_kernel.numeric_versions >
-                                KernelVersion(meta_candidate_same_series.candidate.version).numeric_versions
+                            if (not meta_candidate_same_series or meta_kernel.version_id >
+                                KernelVersion(meta_candidate_same_series.candidate.version).version_id
                                 ):
                                 meta_candidate_same_series = meta
                         else:
                             # higher series
-                            if (not meta_candidate_higher_series or meta_kernel.numeric_versions >
-                                KernelVersion(meta_candidate_higher_series.candidate.version).numeric_versions
+                            if (not meta_candidate_higher_series or meta_kernel.version_id >
+                                KernelVersion(meta_candidate_higher_series.candidate.version).version_id
                                 ):
                                 meta_candidate_higher_series = meta
 
@@ -147,9 +136,9 @@ class APTCheck():
                 match = re.match(r'^(?:linux-image-)(\d.+?)%s$' % active_kernel_type, pkgname)
                 if match:
                     kernel = KernelVersion(match.group(1))
-                    if kernel.series == max_kernel.series and kernel.numeric_versions > max_kernel.numeric_versions:
+                    if kernel.series == max_kernel.series and kernel.version_id > max_kernel.version_id:
                         max_kernel = kernel
-            if max_kernel.numeric_versions != active_kernel.numeric_versions:
+            if max_kernel.version_id != active_kernel.version_id:
                 for pkgname in KERNEL_PKG_NAMES:
                     pkgname = pkgname.replace('VERSION', max_kernel.version).replace("-KERNELTYPE", active_kernel_type)
                     if pkgname in self.cache:

--- a/usr/lib/linuxmint/mintUpdate/checkKernels.py
+++ b/usr/lib/linuxmint/mintUpdate/checkKernels.py
@@ -1,9 +1,12 @@
 #!/usr/bin/python3
-import apt
-import sys
 import os
 import re
-from Classes import CONFIGURED_KERNEL_TYPE, SUPPORTED_KERNEL_TYPES
+import sys
+
+import apt
+
+from Classes import (CONFIGURED_KERNEL_TYPE, SUPPORTED_KERNEL_TYPES,
+                     KernelVersion)
 
 if len(sys.argv) > 1 and sys.argv[1] in SUPPORTED_KERNEL_TYPES:
     CONFIGURED_KERNEL_TYPE = sys.argv[1]
@@ -48,24 +51,16 @@ try:
             signed_kernels.append(full_version)
             if full_version == current_version:
                 used = 1
+
+            # provide a representation of the version which helps sorting the kernels
+            versions = KernelVersion(pkg_version).version_id
+
             if not pkg_data.origins[0].origin:
                 origin = 0
             elif pkg_data.origins[0].origin == 'Ubuntu':
                 origin = 1
             else:
                 origin = 2
-
-            # provide a representation of the version which helps sorting the kernels
-            version_array = pkg_version.replace("-", ".").split(".")
-            versions = []
-            for element in version_array:
-                if len(element) == 1:
-                    element = "00%s" % element
-                elif len(element) == 2:
-                    element = "0%s" % element
-                versions.append(element)
-
-            signed_kernels.append(version)
 
             archive = pkg_data.origins[0].archive
 


### PR DESCRIPTION
- move KernelVersion to Classes.py
- rename KernelVersion.numeric_versions to .version_id because it is not
  strictly numeric and was already called version_id in other contexts
- improve mainline version_id handling in KernelVersion for proper
  sorting of release candidate vs released mainline kernels
- use KernelVersion also in checkKernels.py and sort imports there