### PR TITLE
Drop "(local)" tag from non-repository installed kernels, it's not …

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -408,8 +408,6 @@ class KernelWindow():
                     ACTIVE_KERNEL_VERSION = version_id
                 elif installed:
                     title = _("Installed")
-                if origin == "0":
-                    title += " (local)"
 
                 installable = (installable == "1")
                 if kernel_type == CONFIGURED_KERNEL_TYPE:


### PR DESCRIPTION
…really relevant information and wasn't localized, anyway