### PR TITLE
kernels.ui: flavour > flavor

### DIFF
--- a/usr/share/linuxmint/mintupdate/kernels.ui
+++ b/usr/share/linuxmint/mintupdate/kernels.ui
@@ -380,7 +380,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="no_show_all">True</property>
-                <property name="label" translatable="yes">Kernel flavour:</property>
+                <property name="label" translatable="yes">Kernel flavor:</property>
               </object>
               <packing>
                 <property name="expand">True</property>


### PR DESCRIPTION
I guess our base-spelling should be en_US with en_UK being a localization.