### PR TITLE
Kernelwindow: Show refreshing status page and watch cursor while …

### DIFF
--- a/usr/share/linuxmint/mintupdate/kernels.ui
+++ b/usr/share/linuxmint/mintupdate/kernels.ui
@@ -474,6 +474,42 @@
       </packing>
     </child>
   </object>
+  <object class="GtkBox" id="status_refreshing">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="valign">center</property>
+    <property name="hexpand">True</property>
+    <property name="vexpand">True</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkSpinner" id="status_refreshing_spinner">
+        <property name="name">active_tasks_spinner</property>
+        <property name="height_request">96</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label_refreshing">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Refreshing the list of kernels</property>
+        <attributes>
+          <attribute name="weight" value="bold"/>
+        </attributes>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+  </object>
   <object class="GtkWindow" id="window1">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Kernels</property>


### PR DESCRIPTION
…checkKernels.py is running similar to when the updates list is refreshing:

![mintupdate-kernels-refreshing](https://user-images.githubusercontent.com/13855078/55322148-d0a9a480-547b-11e9-810c-419419597586.png)
