### PR TITLE
Remove mintupdate-autoremove cron job 

### DIFF
--- a/etc/cron.weekly/mintupdate-autoremove
+++ b/etc/cron.weekly/mintupdate-autoremove
@@ -1,3 +1,0 @@
-#!/bin/sh
-echo "\n-- Automatic Removal $(date):\n" >> /var/log/mintupdate.log
-/usr/bin/apt-get autoremove --purge -y >> /var/log/mintupdate.log 2>&1


### PR DESCRIPTION
Must have originally been committed by mistake, it was always meant to be just a systemd service.