### PR TITLE
Fix: NameError: name 'ngettext' is not defined for Ulyana/Focal base

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -19,6 +19,7 @@ from datetime import datetime
 import configparser
 import traceback
 import setproctitle
+from gettext import ngettext
 
 from kernelwindow import KernelWindow
 gi.require_version('Gtk', '3.0')


### PR DESCRIPTION
Fix: NameError: name 'ngettext' is not defined for Ulyana/Focal base

https://paste2.org/LhIN0x2M