### PR TITLE
Order mintupdate-automation-upgrade after network-online

### DIFF
--- a/lib/systemd/system/mintupdate-automation-upgrade.service
+++ b/lib/systemd/system/mintupdate-automation-upgrade.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Update Manager automatic upgrades
+After=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Otherwise, whenever the upgrade timer ticks off while the system is offline, the upgrade script will be called during startup, potentially too early, when network connectivity is not available yet.

This happened to my friend @rua, whose desktop was failing to get its updates, as it would always be powered off at midnight (when the upgrade timer ticks) and on the next boot the upgrade script would run before network was available.  She documented the behaviour (incl. logs etc.) [on the Linux Mint forum](https://forums.linuxmint.com/viewtopic.php?f=47&t=317392)