### PR TITLE
Run upgrade timer at a random point of the day

### DIFF
--- a/lib/systemd/system/mintupdate-automation-upgrade.timer
+++ b/lib/systemd/system/mintupdate-automation-upgrade.timer
@@ -3,7 +3,7 @@ Description=Update Manager automatic upgrades
 
 [Timer]
 OnCalendar=daily
-RandomizedDelaySec=30m
+RandomizedDelaySec=1 day
 Persistent=true
 
 [Install]


### PR DESCRIPTION
`OnCalendar=daily` effectively means “every day at midnight”.  Combined with `RandomizedDelaySec=30m`, this means “at some random point between 00.00 and 00.30”.

Running it then can have unintended consequences:
- As shown in #614, users who shut down their system overnight will end up running upgrades during boot every time; not only does this make the update fail if network isn't up yet (fixed in #614), but it can make boot slower or cause users to have pending updates right after boot, incl. ones that require a reboot (like kernel or libc).
- Many ISPs run various network maintenance tasks, or reboot equipment, at set times during the night, with popular choices being 00.00 and 02.00 (my ISP uses the later, and my internet access indeed goes down at 2am on the dot, every night) ; using a fixed time during the night increases the likelyhood that upgrades will fail day after day.

Instead, I suggest using a random time of the day, which should minimize all those issues.