### PR TITLE
Show right description for grouped updates

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/Classes.py
+++ b/usr/lib/linuxmint/mintUpdate/Classes.py
@@ -75,7 +75,7 @@ class KernelVersion():
 
 class Update():
 
-    def __init__(self, package=None, input_string=None, source_name=None):
+    def __init__(self, package=None, input_string=None, source_name=None, short_description=None):
         self.package_names = []
         if package is not None:
             self.package_names.append(package.name)
@@ -94,7 +94,10 @@ class Update():
             else:
                 self.source_name = self.real_source_name
             self.display_name = self.source_name
-            self.short_description = package.candidate.raw_description
+            if short_description is not None:
+                self.short_description = short_description
+            else:
+                self.short_description = package.candidate.raw_description
             self.description = package.candidate.description
             self.archive = ""
             if (self.new_version != self.old_version):

--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -210,7 +210,15 @@ class APTCheck():
                    "-" in update.old_version and "-" in package.installed.version:
                     update.old_version = package.installed.version
             else:
-                update = Update(package, source_name=source_name)
+                short_description = None
+                # Get the short_description from the source package
+                if not kernel_update and package.name != source_name:
+                    try:
+                        short_description = self.cache[source_name].candidate.raw_description
+                    except:
+                        pass
+
+                update = Update(package, source_name=source_name, short_description=short_description)
                 self.updates[source_name] = update
             if kernel_update:
                 update.type = "kernel"

--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -212,11 +212,8 @@ class APTCheck():
             else:
                 short_description = None
                 # Get the short_description from the source package
-                if not kernel_update and package.name != source_name:
-                    try:
-                        short_description = self.cache[source_name].candidate.raw_description
-                    except:
-                        pass
+                if not kernel_update and package.name != source_name and self.cache.has_key(source_name):
+                    short_description = self.cache[source_name].candidate.raw_description
 
                 update = Update(package, source_name=source_name, short_description=short_description)
                 self.updates[source_name] = update


### PR DESCRIPTION
**Diagnosis:**
Since package are grouped under the `source_name`, then it was showing the description of the real package.

**Solution:**
Get the right package description if available from the `cache` using the `source_name`

**Notes:**
- This fix should not affect kernel updates descriptions
- It should fix #609 