### PR TITLE
Fixed #656: upgrade warnings checkbox now works as expected

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/rel_upgrade.py
+++ b/usr/lib/linuxmint/mintUpdate/rel_upgrade.py
@@ -202,6 +202,8 @@ class Assistant:
             self.vbox_meta.hide()
             if self.check_button.get_active():
                 self.assistant.set_page_complete(self.vbox_prerequesites, True)
+            else:
+                self.assistant.set_page_complete(self.vbox_prerequesites, False)
 
     def show_message(self, icon, msg):
         vbox_content = Gtk.HBox()


### PR DESCRIPTION
Fixed #656: unchecking the "I understand the risk" box on the upgrade warnings page now disables the apply button