### PR TITLE
Avoid unreachable message for non-HTTP mirrors

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -1078,8 +1078,8 @@ class RefreshThread(threading.Thread):
                             if mirror_url.endswith("/"):
                                 mirror_url = mirror_url[:-1]
                             break
-                if mirror_url is None:
-                    # Unable to find the Mint mirror being used..
+                if mirror_url is None or not mirror_url.startswith("http"):
+                    # The Mint mirror being used either cannot be found or is not an HTTP(s) mirror
                     pass
                 elif mirror_url == "http://packages.linuxmint.com":
                     if not self.application.settings.get_boolean("default-repo-is-ok"):


### PR DESCRIPTION
When using a scheme for a mirror that is not HTTP, such as ftp:,
mirror:, or file:, mintupdate reports a message that the mirror cannot
be reached. In actuality, the mirror very well may be reachable but it
cannot check that using an HTTP request. Rather than trying to implement
support for all the protocols in sources.list(5), this skips the check
for any mirror_url that doesn't start with `http`.
