### PR TITLE
Change mintupdate-error-symbolic icon

### DIFF
--- a/usr/share/icons/hicolor/scalable/status/mintupdate-error-symbolic.svg
+++ b/usr/share/icons/hicolor/scalable/status/mintupdate-error-symbolic.svg
@@ -45,13 +45,10 @@
     </filter>
   </defs>
   <path
-     style="opacity:0.75;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 12,10 v 3 h 1 v -3 z m 0,4 v 1 h 1 v -1 z"
-     id="rect846" />
-  <path
-     style="display:block;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-     d="M 7.8457031 0 C 4.7898211 2.1762286 -2.3684758e-15 3.5117188 0 3.5117188 C 1.238713 13.560496 8 16 8 16 C 8 16 8.4064665 15.840985 9.0292969 15.462891 C 8.5961031 14.934807 8.3073886 14.31083 8.1503906 13.648438 C 8.0784654 13.680958 8 13.714844 8 13.714844 C 8 13.714844 3.1699512 11.97262 2.2851562 4.7949219 C 2.2851562 4.7949219 5.7058999 3.8396057 7.8886719 2.2851562 C 9.5845209 3.2607647 13.714844 4.6894531 13.714844 4.6894531 C 13.545552 5.9633032 13.251645 7.0608779 12.892578 8.0175781 C 13.57178 8.0644348 14.157405 8.2415075 14.667969 8.5 C 15.256974 7.0551905 15.734482 5.3631468 16 3.3652344 C 16 3.3652344 10.21989 1.3658516 7.8457031 0 z "
-     id="path15651-4-5" />
+     class="error"
+     style="display:block;overflow:visible;visibility:visible;opacity:1;fill:#e01b24;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
+     d="M 7.9121094 3.5 C 6.1931768 4.7241287 3.5 5.4765625 3.5 5.4765625 C 4.1967763 11.128998 8 12.5 8 12.5 C 8 12.5 11.745156 11.072458 12.5 5.3925781 C 12.5 5.3925781 9.2475915 4.2682914 7.9121094 3.5 z M 7 5 L 9 5 L 9 7.5 C 9 7.5 9 8 8.5 8 L 7.5 8 C 7 8 7 7.5 7 7.5 L 7 5 z M 7.5 9 L 8.5 9 C 8.777 9 9 9.223 9 9.5 L 9 10.5 C 9 10.777 8.777 11 8.5 11 L 7.5 11 C 7.223628 11.000554 6.999445 10.776372 7 10.5 L 7 9.5 C 7 9.223 7.223 9 7.5 9 z "
+     id="path15651-4-7" />
   <g
      transform="translate(-519.00021,368.01034)"
      style="display:inline;filter:url(#filter7554)"
@@ -85,13 +82,11 @@
      style="display:inline"
      id="layer12" />
   <path
-     id="path6"
-     style="color:#bebebe;overflow:visible;fill:#ef2929;marker:none"
-     overflow="visible"
-     d="m 12.5,9 a 3.5,3.5 0 1 0 0,7 3.5,3.5 0 0 0 0,-7 z M 12,10 h 1 v 3 h -1 z m 0,4 h 1 v 1 h -1 z"
-     class="error" />
+     style="display:block;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
+     d="M 7.844483,2e-7 C 4.788185,2.1762288 0,3.5111609 0,3.5111609 1.238882,13.559938 8,16 8,16 c 0,0 6.657874,-2.536363 8,-12.6339284 0,0 -5.781008,-2.0002199 -8.155517,-3.3660714 z m 0.04574,2.2857143 c 1.69608,0.9756114 5.825041,2.4040178 5.825041,2.4040178 -0.95866,7.2125377 -5.715265,9.0245537 -5.715265,9.0245537 0,0 -4.830352,-1.74194 -5.715266,-8.9196429 0,0 3.42242,-0.9544829 5.60549,-2.5089286 z"
+     id="path15651-4" />
   <path
-     style="display:block;overflow:visible;visibility:visible;opacity:0.35;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-     d="M 7.9121094 3.5 C 6.1931764 4.7241287 3.5 5.4765625 3.5 5.4765625 C 4.196776 11.128998 8 12.5 8 12.5 C 8 10.420768 9.2838051 8.3446537 11.845703 8.0410156 C 12.133007 7.2816983 12.365154 6.4072334 12.5 5.3925781 C 12.5 5.3925781 9.2475914 4.2682914 7.9121094 3.5 z "
-     id="path15651-4-7" />
+     style="color:#bebebe;overflow:visible;fill:#bebebe;fill-opacity:1;enable-background:new"
+     d="m 7,5 v 2.5000003 c 0,0 0,0.5 0.5,0.5 h 1 c 0.5,0 0.5,-0.5 0.5,-0.5 V 5 Z m 0.5,4.0000003 c -0.277,0 -0.5,0.223 -0.5,0.5 V 10.5 c -5.55e-4,0.276372 0.223628,0.500554 0.5,0.5 h 1 C 8.777,11 9,10.777 9,10.5 V 9.5000003 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 z"
+     id="path4-3-7-3" />
 </svg>


### PR DESCRIPTION
The exclamation mark in the current icon is barely visible and might
look like schmutz on the screen.
Therefore change it a little bit and make the mark bigger.

Old icon on the right, new icon in the middle:
![screenshot-cinnamon-2021-09-16-230607](https://user-images.githubusercontent.com/8415124/133687040-74127bb4-6de2-41f5-abe5-5a4e9aa45084.png)


