### PR TITLE
Add total download size support for Flatpak and Spices

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -1007,6 +1007,7 @@ class RefreshThread(threading.Thread):
                     model.set_value(iter, UPDATE_OBJ, update)
                     num_software += 1
                     num_visible += 1
+                    download_size += update.size
 
             if FLATPAK_SUPPORT and self.application.flatpak_updater and not is_self_update:
                 type_sort_key = 5
@@ -1049,6 +1050,7 @@ class RefreshThread(threading.Thread):
                         model.set_value(iter, UPDATE_OBJ, update)
                         num_software += 1
                         num_visible += 1
+                        download_size += update.size
 
             if tracker.active:
                 if tracker.notify():


### PR DESCRIPTION
With this PR flatpaks and spices (applets/themes/etc.) are counted into the total download size shown at the bottom of mintupdate.

The number of packages to update is counted for all types but currently the size is only counted for apt packages.


## Before:
![before](https://user-images.githubusercontent.com/52620063/206236499-7829a324-6e19-406f-90ac-14ab185571ae.png)

## After:
![after](https://user-images.githubusercontent.com/52620063/206236541-d533cd66-7de4-47c8-9065-2b62a597541e.png)
