### PR TITLE
simplify boolean expressions

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/Classes.py
+++ b/usr/lib/linuxmint/mintUpdate/Classes.py
@@ -252,7 +252,7 @@ class UpdateTracker():
     # Updates the record for a particular update
     def update(self, update):
         self.refreshed_update_names.append(update.real_source_name)
-        if not update.real_source_name in self.tracked_updates['updates']:
+        if update.real_source_name not in self.tracked_updates['updates']:
             update_record = {}
             update_record['type'] = update.type
             update_record['since'] = self.today
@@ -292,7 +292,7 @@ class UpdateTracker():
         if os.path.exists("/var/log/apt/history.log"):
             logs = subprocess.getoutput("cat /var/log/apt/history.log")
             for event in logs.split("\n\n"):
-                if not "Upgrade: " in event:
+                if "Upgrade: " not in event:
                     continue
                 end_date = None
                 upgrade = None
@@ -308,7 +308,7 @@ class UpdateTracker():
             try:
                 logs = subprocess.getoutput("zcat /var/log/apt/history.log*gz")
                 for event in logs.split("\n\n"):
-                    if not "Upgrade: " in event:
+                    if "Upgrade: " not in event:
                         continue
                     end_date = None
                     upgrade = None
@@ -374,7 +374,7 @@ class UpdateTracker():
     def record(self):
         # Purge non-refreshed updates
         for name in list(self.tracked_updates['updates'].keys()):
-            if not name in self.refreshed_update_names:
+            if name not in self.refreshed_update_names:
                 del self.tracked_updates['updates'][name]
         # Update the check date
         self.tracked_updates['checked'] = self.today

--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -162,7 +162,7 @@ class APTCheck():
 
     def get_kernel_version_from_meta_package(self, pkg):
         for dependency in pkg.dependencies:
-            if not dependency.target_versions or not dependency.rawtype == "Depends":
+            if not dependency.target_versions or dependency.rawtype != "Depends":
                 return None
             deppkg = dependency.target_versions[0]
             if deppkg.source_name in ("linux", "linux-signed"):
@@ -206,8 +206,8 @@ class APTCheck():
                 update.add_package(package)
                 # Adjust update.old_version for kernel updates to try and
                 # match the kernel, not the meta
-                if kernel_update and package.is_installed and not \
-                   "-" in update.old_version and "-" in package.installed.version:
+                if kernel_update and package.is_installed and \
+                        "-" not in update.old_version and "-" in package.installed.version:
                     update.old_version = package.installed.version
             else:
                 update = Update(package, source_name=source_name)

--- a/usr/lib/linuxmint/mintUpdate/checkKernels.py
+++ b/usr/lib/linuxmint/mintUpdate/checkKernels.py
@@ -41,7 +41,7 @@ try:
                 pkg_version = pkg.installed.version
             else:
                 # only offer to install same-type kernels
-                if not kernel_type == CONFIGURED_KERNEL_TYPE:
+                if kernel_type != CONFIGURED_KERNEL_TYPE:
                     continue
                 if pkg.candidate and pkg.candidate.downloadable:
                     installable = 1
@@ -67,7 +67,7 @@ try:
 
             # get support duration
             supported_tag = pkg_data.record.get("Supported")
-            if not supported_tag and origin == 1 and not "-proposed" in pkg_data.origins[0].archive:
+            if not supported_tag and origin == 1 and "-proposed" not in pkg_data.origins[0].archive:
                 # Workaround for Ubuntu releasing kernels by copying straight from
                 # -proposed and only adding the Supported tag shortly after.
                 # To avoid user confusion in the time in-between we just assume

--- a/usr/lib/linuxmint/mintUpdate/checkWarnings.py
+++ b/usr/lib/linuxmint/mintUpdate/checkWarnings.py
@@ -29,13 +29,12 @@ try:
     # Get changes
     for pkg in cache.packages:
         if (not depcache.marked_keep(pkg) and
-            (depcache.marked_install(pkg) or depcache.marked_upgrade(pkg)) and
-            not pkg.name in selection and
-            not "%s:%s" % (pkg.name, pkg.architecture) in selection and
-            not pkg.name in packages_to_install
-            ):
+                (depcache.marked_install(pkg) or depcache.marked_upgrade(pkg)) and
+                pkg.name not in selection and
+                "%s:%s" % (pkg.name, pkg.architecture) not in selection and
+                pkg.name not in packages_to_install):
             packages_to_install.append(pkg.name)
-        if depcache.marked_delete(pkg) and not pkg.name in packages_to_remove:
+        if depcache.marked_delete(pkg) and pkg.name not in packages_to_remove:
             packages_to_remove.append(pkg.name)
     installations = ' '.join(packages_to_install)
     removals = ' '.join(packages_to_remove)

--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -67,7 +67,7 @@ class InstallKernelThread(threading.Thread):
                         if pkg.is_installed:
                             # skip kernel_type independent packages (headers) if another kernel of the
                             # same version but different type is installed
-                            if not kernel.type in name and self.package_needed_by_another_kernel(kernel.version, kernel.type):
+                            if kernel.type not in name and self.package_needed_by_another_kernel(kernel.version, kernel.type):
                                 continue
                             pkg_line = "%s\tpurge\n" % name
                             f.write(pkg_line.encode("utf-8"))
@@ -443,7 +443,7 @@ class KernelWindow():
 
                 release = archive.split("-", 1)[0]
                 if support_duration and origin == "1":
-                    if not release in hwe_support_duration:
+                    if release not in hwe_support_duration:
                         hwe_support_duration[release] = []
                     if not [x for x in hwe_support_duration[release] if x[0] == page_label]:
                         hwe_support_duration[release].append([page_label, support_duration])
@@ -513,9 +513,9 @@ class KernelWindow():
                 if support_info:
                     (page_label, support_duration, support_end_str, is_end_of_life) = support_info[0]
                     if support_end_str:
-                        if not kernel_type in supported_kernels.keys():
+                        if kernel_type not in supported_kernels.keys():
                             supported_kernels[kernel_type] = []
-                        if not page_label in supported_kernels[kernel_type]:
+                        if page_label not in supported_kernels[kernel_type]:
                             supported_kernels[kernel_type].append(page_label)
                             support_status = '%s %s' % (_("Supported until"), support_end_str)
                             newest_supported_in_series = True

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -114,7 +114,7 @@ class CacheWatcher(threading.Thread):
                 try:
                     cachetime = os.path.getmtime(self.pkgcache)
                     statustime = os.path.getmtime(self.dpkgstatus)
-                    if (not cachetime == self.cachetime or not statustime == self.statustime) and \
+                    if (cachetime != self.cachetime or statustime != self.statustime) and \
                         not self.application.dpkg_locked():
                         self.cachetime = cachetime
                         self.statustime = statustime
@@ -890,7 +890,7 @@ class RefreshThread(threading.Thread):
             lines = output.split("---EOL---")
             if len(lines):
                 for line in lines:
-                    if not "###" in line:
+                    if "###" not in line:
                         continue
 
                     # Create update object
@@ -1246,7 +1246,7 @@ class RefreshThread(threading.Thread):
                             for pkg2 in changes:
                                 if o.name == pkg2.name:
                                     pkgFound = True
-                            if pkgFound == False:
+                            if not pkgFound:
                                 newPkg = cache[o.name]
                                 changes.append(newPkg)
                                 foundSomething = True


### PR DESCRIPTION
I did some readability improvements to some boolean checks.
Instead of checking if an element is contained in an list and inverting the condition with `not` , I used `not in`.
Instead of checking if two objects are equal and inverting the condition with `not` , I used` !=` (not equal).
And instead of checking if an boolean is equal to `False `, I used `not` directly.