### PR TITLE
add missing variable causing potential type error

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/Classes.py
+++ b/usr/lib/linuxmint/mintUpdate/Classes.py
@@ -534,7 +534,7 @@ class FlatpakUpdate():
         try:
             b = GLib.Bytes.new(json_data["metadata"].encode())
             inst.metadata.load_from_bytes(b, GLib.KeyFileFlags.NONE)
-        except GLib.Error:
+        except GLib.Error as e:
             print("unable to decode op metadata: %s" % e.message)
             pass
 


### PR DESCRIPTION
In line 538 `print`  try's to access e, but e is not defined. I assume that e should be the cached `GLib.Error`.