### PR TITLE
remove unused variables

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/Classes.py
+++ b/usr/lib/linuxmint/mintUpdate/Classes.py
@@ -295,7 +295,6 @@ class UpdateTracker():
                 if "Upgrade: " not in event:
                     continue
                 end_date = None
-                upgrade = None
                 for line in event.split("\n"):
                     line = line.strip()
                     if line.startswith("End-Date: "):
@@ -311,7 +310,6 @@ class UpdateTracker():
                     if "Upgrade: " not in event:
                         continue
                     end_date = None
-                    upgrade = None
                     for line in event.split("\n"):
                         line = line.strip()
                         if line.startswith("End-Date: "):

--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -488,7 +488,6 @@ class KernelWindow():
                             support_duration = 10 + point_release * 6
 
                 support_end_str = ""
-                is_end_of_life = False
                 (support_end_year, support_end_month) = get_maintenance_end_date(self.release_dates[release][0], support_duration)
                 is_end_of_life = (now.year > support_end_year or (now.year == support_end_year and now.month > support_end_month))
                 if not is_end_of_life:


### PR DESCRIPTION
The variable `upgrade` in the method `get_latest_apt_upgrade` is always None and also not unused in this function. 
The variable `is_end_of_life` assigned in line 492, so no need to define it with `False` first.