### PR TITLE
Added mintupdate style class to the window for easier theming

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -1402,6 +1402,9 @@ class MintUpdate():
 
             self.window.set_icon_name("mintupdate")
 
+            # Add mintupdate style class for easier theming
+            self.window.get_style_context().add_class('mintupdate')
+
             accel_group = Gtk.AccelGroup()
             self.window.add_accel_group(accel_group)
 
@@ -2132,6 +2135,10 @@ class MintUpdate():
         window = builder.get_object("main_window")
         window.set_title(_("Information"))
         window.set_icon_name("mintupdate")
+
+        # Add mintupdate style class for easier theming
+        self.window.get_style_context().add_class('mintupdate')
+
         textbuffer = builder.get_object("log_textview").get_buffer()
         window.connect("destroy", destroy_window)
         builder.get_object("close_button").connect("clicked", destroy_window)
@@ -2153,6 +2160,9 @@ class MintUpdate():
         window = builder.get_object("main_window")
         window.set_icon_name("mintupdate")
         window.set_title(_("History of Updates"))
+
+        # Add mintupdate style class for easier theming
+        self.window.get_style_context().add_class('mintupdate')
 
         (COL_DATE, COL_TYPE, COL_NAME, COL_OLD_VER, COL_NEW_VER) = range(5)
         model = Gtk.TreeStore(str, str, str, str, str)
@@ -2359,6 +2369,10 @@ class MintUpdate():
         window.set_transient_for(self.window)
         window.set_title(_("Preferences"))
         window.set_icon_name("mintupdate")
+
+        # Add mintupdate style class for easier theming
+        self.window.get_style_context().add_class('mintupdate')
+
         window.connect("destroy", self.close_preferences, window)
 
         switch_container = builder.get_object("switch_container")


### PR DESCRIPTION
The PR adds CSS class to the mintupdate window. This allows to create CSS selectors for the window, and therefore theming with GTK 3 stylesheets.

It is inspired from Thunar File Manager ([https://gitlab.xfce.org/xfce/thunar/-/blob/master/thunar/thunar-window.c#L848-850](https://gitlab.xfce.org/xfce/thunar/-/blob/master/thunar/thunar-window.c#L848-850))
