### PR TITLE
Fix changelog retrieval for kernel updates

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -165,7 +165,7 @@ class APTCheck():
             if not dependency.target_versions or dependency.rawtype != "Depends":
                 return None
             deppkg = dependency.target_versions[0]
-            if deppkg.source_name in ("linux", "linux-signed"):
+            if deppkg.source_name in ("linux", "linux-signed") or deppkg.source_name.startswith("linux-hwe"):
                 return deppkg.source_version
             if deppkg.source_name.startswith("linux-meta"):
                 return self.get_kernel_version_from_meta_package(deppkg)

--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -162,6 +162,7 @@ class ChangelogRetriever(threading.Thread):
         self.source_package = update.real_source_name
         self.version = update.new_version
         self.origin = update.origin
+        self.is_kernel_update = update.type == "kernel"
         self.application = application
         # get the proxy settings from gsettings
         self.ps = proxygsettings.get_proxy_settings()
@@ -275,7 +276,11 @@ class ChangelogRetriever(threading.Thread):
             changelog_sources.append("http://packages.linuxmint.com/dev/" + self.source_package + "_" + self.version + "_amd64.changes")
             changelog_sources.append("http://packages.linuxmint.com/dev/" + self.source_package + "_" + self.version + "_i386.changes")
         elif self.origin == "ubuntu":
-            if (self.source_package.startswith("lib")):
+            if self.is_kernel_update:
+                # Ubuntu HWE kernel versions end with '~' followed by the Ubuntu version (e.g. ~22.04.1). This suffix needs to be removed to get the correct changelog URL
+                kernel_version = self.version.split("~")[0]
+                changelog_sources.append("https://changelogs.ubuntu.com/changelogs/pool/main/l/linux/linux_%s/changelog" % (kernel_version))
+            elif (self.source_package.startswith("lib")):
                 changelog_sources.append("https://changelogs.ubuntu.com/changelogs/pool/main/%s/%s/%s_%s/changelog" % (self.source_package[0:4], self.source_package, self.source_package, self.version))
                 changelog_sources.append("https://changelogs.ubuntu.com/changelogs/pool/multiverse/%s/%s/%s_%s/changelog" % (self.source_package[0:4], self.source_package, self.source_package, self.version))
                 changelog_sources.append("https://changelogs.ubuntu.com/changelogs/pool/universe/%s/%s/%s_%s/changelog" % (self.source_package[0:4], self.source_package, self.source_package, self.version))
@@ -286,7 +291,9 @@ class ChangelogRetriever(threading.Thread):
                 changelog_sources.append("https://changelogs.ubuntu.com/changelogs/pool/universe/%s/%s/%s_%s/changelog" % (self.source_package[0], self.source_package, self.source_package, self.version))
                 changelog_sources.append("https://changelogs.ubuntu.com/changelogs/pool/restricted/%s/%s/%s_%s/changelog" % (self.source_package[0], self.source_package, self.source_package, self.version))
         elif self.origin == "debian":
-            if (self.source_package.startswith("lib")):
+            if self.is_kernel_update:
+                changelog_sources.append("https://metadata.ftp-master.debian.org/changelogs/main/l/linux/linux_%s_changelog" % (self.version))
+            elif (self.source_package.startswith("lib")):
                 changelog_sources.append("https://metadata.ftp-master.debian.org/changelogs/main/%s/%s/%s_%s_changelog" % (self.source_package[0:4], self.source_package, self.source_package, self.version))
                 changelog_sources.append("https://metadata.ftp-master.debian.org/changelogs/contrib/%s/%s/%s_%s_changelog" % (self.source_package[0:4], self.source_package, self.source_package, self.version))
                 changelog_sources.append("https://metadata.ftp-master.debian.org/changelogs/non-free/%s/%s/%s_%s_changelog" % (self.source_package[0:4], self.source_package, self.source_package, self.version))


### PR DESCRIPTION
This PR applies some code changes to allow the Update Manager to properly retrieve Linux kernel changelogs. I find them extremely useful to see the list of security patches and fixes included in each kernel update.

Without this PR, the manager tries to fetch (non-HWE) kernel changelogs from `https://changelogs.ubuntu.com/changelogs/pool/main/l/linux-meta/linux-meta_{kernel_version}`, which does not work because the version of the linux-meta package does not match the kernel one (for example, the latest 5.15 kernel at the time of writing is 5.15.0-91.101, but the corresponding linux-meta version is 5.15.0.91.88).
Furthermore, even if the version were correct, linux-meta changelogs do not contain any information about what changed in a specific kernel update (see [this changelog](https://changelogs.ubuntu.com/changelogs/pool/main/l/linux-meta/linux-meta_5.15.0.91.88/changelog) for example).

I've made sure that the changelog is correctly fetched for HWE kernels too. Before this PR, the Update Manager displayed `linux-meta-hwe-X.Y` changelogs for those kernels (e.g. https://changelogs.ubuntu.com/changelogs/pool/main/l/linux-meta-hwe-6.5/).  In contrast to non-HWE kernels, fetching linux-meta-hwe changelogs worked because the checkAPT script was grouping kernel packages using the meta package version (which was then used to retrieve the changelog) instead of the actual kernel version. 

I couldn't test this PR on LMDE, but everything should still work fine there.

Fixes #705