### PR TITLE
Fix two instances of a grammatical error within mintupdate-en_GB.po

### DIFF
--- a/po/mintupdate-en_GB.po
+++ b/po/mintupdate-en_GB.po
@@ -851,10 +851,10 @@ msgstr "Reboot required"
 #: usr/lib/linuxmint/mintUpdate/mintUpdate.py:795
 #: usr/lib/linuxmint/mintUpdate/mintUpdate.py:802
 msgid ""
-"You have installed updates that require a reboot to take effect, please "
+"You have installed updates that require a reboot to take effect. Please "
 "reboot your system as soon as possible."
 msgstr ""
-"You have installed updates that require a reboot to take effect, please "
+"You have installed updates that require a reboot to take effect. Please "
 "reboot your system as soon as possible."
 
 #: usr/lib/linuxmint/mintUpdate/mintUpdate.py:750


### PR DESCRIPTION
If one has two clauses each of which could stand perfectly well as its own sentence, then one cannot (grammatically) jam the clauses together with a comma. Rather, one needs to start a new sentence (or, where appropriate, use a colon, a semi-colon, or a dash).