### PR TITLE
Check all repositorites for package type

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/Classes.py
+++ b/usr/lib/linuxmint/mintUpdate/Classes.py
@@ -145,7 +145,7 @@ class Update():
                 if origin.origin == "linuxmint":
                     if origin.component == "romeo":
                         self.type = "unstable"
-                break
+                        break
             if package.candidate.section == "kernel" or self.package_name.startswith("linux-headers") or self.real_source_name in ["linux", "linux-kernel", "linux-signed", "linux-meta"]:
                 self.type = "kernel"
 


### PR DESCRIPTION
When Ubuntu packages are updated because of security issues, it looks like their artifacts are published on both `-updates` and `-security` repositories. (i.e. [libssh](https://launchpad.net/ubuntu/+source/libssh/0.10.6-2ubuntu0.1))

Currently, to mark a package as a `Security update`, only the first repo's name is checked (and it is usually the `-updates` repo), so the package is not marked as a security update.

If there are multiple repositories as origin for a package, this change loops all repos and not just the first one.

- This is partial revert for #907 on usr/lib/linuxmint/mintUpdate/Classes.py, [line 148](https://github.com/linuxmint/mintupdate/pull/907/files#diff-edbe375d0b691c1bb7af4334afafd9e955fff0eac292d4b1bb4ca9716cadf3e4L147-L148)

-----

For some security packages, `package.candidate.origins` looks like this:
```
[<Origin component:'main' archive:'noble-updates' origin:'Ubuntu' label:'Ubuntu' site:'archive.ubuntu.com' isTrusted:True>,
 <Origin component:'main' archive:'noble-security' origin:'Ubuntu' label:'Ubuntu' site:'security.ubuntu.com' isTrusted:True>]
```

Fixes #952
