### PR TITLE
Purge residual `linux-tools-*` kernel packages

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -429,7 +429,11 @@ class KernelWindow():
             for kernel in kernels:
                 _KERNEL_PKG_NAMES = KERNEL_PKG_NAMES.copy()
                 if kernel.installed:
-                    _KERNEL_PKG_NAMES.append("linux-image-unsigned-VERSION-KERNELTYPE") # mainline, remove only
+                    # also purge existing residual kernel packages
+                    _KERNEL_PKG_NAMES.append("linux-image-unsigned-VERSION-KERNELTYPE")
+                    _KERNEL_PKG_NAMES.append("linux-tools-VERSION")
+                    _KERNEL_PKG_NAMES.append("linux-tools-VERSION-KERNELTYPE")
+
                 for name in _KERNEL_PKG_NAMES:
                     name = name.replace("VERSION", kernel.version).replace("-KERNELTYPE", kernel.type)
                     if name in self.cache:


### PR DESCRIPTION
If there are installed residual `linux-tools-VERSION` and `linux-tools-VERSION-KERNELTYPE` packages, remove them with other kernel packages with the same version.

Also, just below this change, packages are checked for whether they are already installed, and then they are added to the purge list. So, the app doesn't try to remove `linux-tools` unconditionally:
https://github.com/linuxmint/mintupdate/blob/afa341f6d01c8ba1e84acb285958fd32038b6fed/usr/lib/linuxmint/mintUpdate/kernelwindow.py#L437-L438

-----
Fixes #946