### PR TITLE
Typo fix for romanian translation

### DIFF
--- a/po/mintupdate-ro.po
+++ b/po/mintupdate-ro.po
@@ -420,7 +420,7 @@ msgstr "uname -a"
 
 #: usr/share/help/C/mintupdate/kernels.page:54(title)
 msgid "Installing and removing kernels"
-msgstr "Instalarea și eliminaea nucleelor"
+msgstr "Instalarea și eliminarea nucleelor"
 
 #: usr/share/help/C/mintupdate/kernels.page:56(p)
 msgid "You can install and remove kernels from the Update Manager."


### PR DESCRIPTION
The word "eliminaea" is a typo from the word "eliminarea"