### PR TITLE
Improve size_to_string

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -88,19 +88,20 @@ Notify.init(_("Update Manager"))
 
 BLACKLIST_PKG_NAME = 0
 
-GIGABYTE = 1000 ** 3
-MEGABYTE = 1000 ** 2
-KILOBYTE = 1000
-
 
 def size_to_string(size):
-    if (size >= GIGABYTE):
-        return "%d %s" % (size // GIGABYTE,  _("GB"))
-    if (size >= (MEGABYTE)):
-        return "%d %s" % (size // MEGABYTE,  _("MB"))
-    if (size >= KILOBYTE):
-        return "%d %s" % (size // KILOBYTE,  _("KB"))
-    return "%d %s" % (size,  _("B"))
+    f_size = float(size)
+    units = [_('B'), _('KB'), _('MB'), _('GB')]
+    for unit in units:
+        if f_size >= 1000:
+            f_size /= 1000
+        else:
+            break
+    if f_size >= 10:
+        return f"{f_size:.0f} {unit}"
+    else:
+        return f"{f_size:.1f} {unit}"
+
 
 def name_search_func(model, column, key, iter):
     name = model.get_value(iter, column)


### PR DESCRIPTION
Use a float instead to format the size to a string. And if the value is less than 10, show one decimal.

I found it really weird that when I added/remove a 800 MB flatpak download the size at the bottom still said 1 GB download regardless... Quite a bit of difference between 1.0 and 1.8 GB to download. And even weirder that it rounded it to 1 instead of 2 which was closer.

<img width="878" height="510" alt="pic1" src="https://github.com/user-attachments/assets/5804a009-c8d2-45c8-b858-512204ea5297" />
<img width="876" height="520" alt="pic2" src="https://github.com/user-attachments/assets/bf423ebe-a7a8-4ca3-9d7f-fe4e0ac0ca3c" />
