### PR TITLE
Warn from system tray when reboot is required

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -639,12 +639,13 @@ class MintUpdate():
 
     @_idle
     def show_updates_in_UI(self, num_visible, num_software, num_security, download_size, is_self_update, model_items):
+        status_string = ""
+
         if num_visible > 0:
             self.logger.write("Found %d software updates" % num_visible)
             if is_self_update:
                 self.ui_stack.set_visible_child_name("self_update_page")
                 self.ui_statusbar.set_visible(False)
-                status_string = ""
                 details = []
 
                 for item in model_items:
@@ -660,13 +661,19 @@ class MintUpdate():
                 self.ui_install_button.set_sensitive(True)
                 self.ui_window.set_sensitive(True)
             systray_tooltip = gettext.ngettext("%d update available", "%d updates available", num_visible) % num_visible
-            self.set_status(status_string, systray_tooltip, "mintupdate-updates-available-symbolic", True)
+
+            if not self.reboot_required:
+                self.set_status(status_string, systray_tooltip, "mintupdate-updates-available-symbolic", True)
         else:
             self.logger.write("System is up to date")
             self.ui_stack.set_visible_child_name("success_page")
-            self.set_status("", _("Your system is up to date"), "mintupdate-up-to-date-symbolic",
-                                        not self.settings.get_boolean("hide-systray"))
 
+            if not self.reboot_required:
+                self.set_status("", _("Your system is up to date"), "mintupdate-up-to-date-symbolic",
+                                not self.settings.get_boolean("hide-systray"))
+
+        if self.reboot_required:
+            self.set_status(status_string, _("Reboot required"), "mintupdate-warning-symbolic", True)
 
         self.ui_notebook_details.set_current_page(0)
 

--- a/usr/share/icons/hicolor/scalable/status/mintupdate-warning-symbolic.svg
+++ b/usr/share/icons/hicolor/scalable/status/mintupdate-warning-symbolic.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="16"
+   height="16"
+   style="enable-background:new">
+  <metadata>
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Linux Mint Update Manager - Warning icon</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title>Linux Mint Update Manager - Warning icon</title>
+  <defs>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       id="filter01">
+      <feBlend
+         mode="darken"
+         in2="BackgroundImage"
+         id="feBlend01" />
+    </filter>
+  </defs>
+  <path
+     class="warning"
+     style="display:block;overflow:visible;visibility:visible;opacity:1;fill:#f57900;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
+     d="M 7.9121094 3.5 C 6.1931768 4.7241287 3.5 5.4765625 3.5 5.4765625 C 4.1967763 11.128998 8 12.5 8 12.5 C 8 12.5 11.745156 11.072458 12.5 5.3925781 C 12.5 5.3925781 9.2475915 4.2682914 7.9121094 3.5 z M 7 5 L 9 5 L 9 7.5 C 9 7.5 9 8 8.5 8 L 7.5 8 C 7 8 7 7.5 7 7.5 L 7 5 z M 7.5 9 L 8.5 9 C 8.777 9 9 9.223 9 9.5 L 9 10.5 C 9 10.777 8.777 11 8.5 11 L 7.5 11 C 7.223628 11.000554 6.999445 10.776372 7 10.5 L 7 9.5 C 7 9.223 7.223 9 7.5 9 z "
+     id="path01" />
+  <g
+     transform="translate(-519.00021,368.01034)"
+     style="display:inline;filter:url(#filter01)"
+     id="layer01" />
+  <g
+     transform="translate(-278.00001,-248.98966)"
+     style="display:inline"
+     id="layer02" />
+  <g
+     transform="translate(-519.00021,368.01034)"
+     style="display:inline"
+     id="layer03" />
+  <g
+     transform="translate(-519.00021,368.01034)"
+     style="display:inline"
+     id="layer04" />
+  <g
+     transform="translate(-519.00021,368.01034)"
+     style="display:inline"
+     id="layer05" />
+  <g
+     transform="translate(-278.00001,-98.98966)"
+     style="display:inline"
+     id="layer06" />
+  <g
+     transform="translate(-278.00001,-98.98966)"
+     style="display:inline"
+     id="layer07" />
+  <g
+     transform="translate(-519.00021,368.01034)"
+     style="display:inline"
+     id="layer08" />
+  <path
+     style="display:block;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
+     d="M 7.844483,2e-7 C 4.788185,2.1762288 0,3.5111609 0,3.5111609 1.238882,13.559938 8,16 8,16 c 0,0 6.657874,-2.536363 8,-12.6339284 0,0 -5.781008,-2.0002199 -8.155517,-3.3660714 z m 0.04574,2.2857143 c 1.69608,0.9756114 5.825041,2.4040178 5.825041,2.4040178 -0.95866,7.2125377 -5.715265,9.0245537 -5.715265,9.0245537 0,0 -4.830352,-1.74194 -5.715266,-8.9196429 0,0 3.42242,-0.9544829 5.60549,-2.5089286 z"
+     id="path02" />
+  <path
+     style="color:#bebebe;overflow:visible;fill:#bebebe;fill-opacity:1;enable-background:new"
+     d="m 7,5 v 2.5000003 c 0,0 0,0.5 0.5,0.5 h 1 c 0.5,0 0.5,-0.5 0.5,-0.5 V 5 Z m 0.5,4.0000003 c -0.277,0 -0.5,0.223 -0.5,0.5 V 10.5 c -5.55e-4,0.276372 0.223628,0.500554 0.5,0.5 h 1 C 8.777,11 9,10.777 9,10.5 V 9.5000003 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 z"
+     id="path03" />
+</svg>


### PR DESCRIPTION
If automated updates are enabled, one may miss for a time that there is a need for a system reboot.

This change warns from the system tray that a system reboot is required.

- Fixes #630

-----
<details open>
<summary><b>Hierarchy of icon choice for informing from the system tray</b></summary>

Currently:
1. Show new updates are available
1. Show system is up to date

**(edited)** The order with this change:
1. Show a reboot is required
1. Show new updates are available
1. Show system is up to date
</details>

**Screenshot of the change:** (panel and tray icon are exaggerated for convenience)
<img width="567" height="552" alt="reboot-required" src="https://github.com/user-attachments/assets/bfb5cd9e-0993-4423-ba62-e63999e16834" />

----

GTK SVG color use reference:
- https://docs.gtk.org/gtk4/icon-format.html#supported-svg-attributes