### PR TITLE
Resolve 'reboot' vs 'restart' discrepancy from newly merged PRs

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/mintUpdate.py
+++ b/usr/lib/linuxmint/mintUpdate/mintUpdate.py
@@ -674,7 +674,7 @@ class MintUpdate():
                                 not self.settings.get_boolean("hide-systray"))
 
         if self.reboot_required:
-            self.set_status(status_string, _("Reboot required"), "mintupdate-warning-symbolic", True)
+            self.set_status(status_string, _("Restart required"), "mintupdate-warning-symbolic", True)
 
         self.ui_notebook_details.set_current_page(0)
 


### PR DESCRIPTION
Newly merged PRs create a naming conflict and will create problems for `*.po` files probably. This change solves this.

- Related to #993 and #991