### PR TITLE
Use XDG_STATE_HOME for config path

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/Classes.py
+++ b/usr/lib/linuxmint/mintUpdate/Classes.py
@@ -33,7 +33,10 @@ CONFIGURED_KERNEL_TYPE = settings.get_string("selected-kernel-type")
 if CONFIGURED_KERNEL_TYPE not in SUPPORTED_KERNEL_TYPES:
     CONFIGURED_KERNEL_TYPE = "-generic"
 
-CONFIG_PATH = os.path.expanduser("~/.linuxmint/mintupdate")
+CONFIG_PATH = os.path.join(os.environ.get("XDG_STATE_HOME", os.path.expanduser("~/.local/state")), "mintupdate")
+# Fall back to legacy path if it exists
+if os.path.isdir(os.path.expanduser("~/.linuxmint/mintupdate")):
+    CONFIG_PATH = os.path.expanduser("~/.linuxmint/mintupdate")
 
 # Used as a decorator to run things in the background
 def _async(func):


### PR DESCRIPTION
Use XDG_STATE_HOME rather than ~/.linuxmint for storing updates.json if
the latter does not exist. This cuts down on the amount of cruft in
user's home directories. If the older path exists, it will be used,
meaning there will be no change to existing installs/setups.
