### PR TITLE
checkAPT: handle packages without a candidate version

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/checkAPT.py
+++ b/usr/lib/linuxmint/mintUpdate/checkAPT.py
@@ -52,6 +52,12 @@ class APTCheck():
 
         # Package updates
         for pkg in changes:
+            if pkg.candidate is None:
+                # Installed package has no candidate version (e.g. orphaned
+                # or removed from the repositories). Skip it so the rest of
+                # the update list can still be refreshed.
+                print("Skipping package without candidate version: %s" % pkg.name)
+                continue
             if (pkg.is_installed and pkg.candidate.version != pkg.installed.version):
                 if (pkg.marked_upgrade or pkg.marked_downgrade):
                     self.add_update(pkg)


### PR DESCRIPTION
Skip installed packages whose apt cache candidate is `None` instead of crashing with `AttributeError: 'NoneType' object has no attribute 'version'` in `find_changes`. This can happen when a package is orphaned or removed from the configured repositories (e.g. `snapd` after disabling snap), and previously caused the entire update list refresh to fail.

Closes #1059