### PR TITLE
Purge residual linux-hwe-* `tools` and `headers` kernel packages

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -439,9 +439,15 @@ class KernelWindow():
                     _KERNEL_PKG_NAMES.append("linux-image-unsigned-VERSION-KERNELTYPE")
                     _KERNEL_PKG_NAMES.append("linux-tools-VERSION")
                     _KERNEL_PKG_NAMES.append("linux-tools-VERSION-KERNELTYPE")
+                    _KERNEL_PKG_NAMES.append("linux-hwe-MAJOR_MINOR_VERSION-tools-VERSION")
+                    _KERNEL_PKG_NAMES.append("linux-hwe-MAJOR_MINOR_VERSION-headers-VERSION")
 
                 for name in _KERNEL_PKG_NAMES:
-                    name = name.replace("VERSION", kernel.version).replace("-KERNELTYPE", kernel.type)
+                    name = (name
+                        .replace("MAJOR_MINOR_VERSION", kernel.version.rpartition('.')[0])
+                        .replace("VERSION", kernel.version)
+                        .replace("-KERNELTYPE", kernel.type)
+                    )
                     if name in self.cache:
                         pkg = self.cache[name]
                         if kernel.installed:

--- a/usr/lib/linuxmint/mintUpdate/kernelwindow.py
+++ b/usr/lib/linuxmint/mintUpdate/kernelwindow.py
@@ -436,11 +436,13 @@ class KernelWindow():
                 _KERNEL_PKG_NAMES = KERNEL_PKG_NAMES.copy()
                 if kernel.installed:
                     # also purge existing residual kernel packages
-                    _KERNEL_PKG_NAMES.append("linux-image-unsigned-VERSION-KERNELTYPE")
-                    _KERNEL_PKG_NAMES.append("linux-tools-VERSION")
-                    _KERNEL_PKG_NAMES.append("linux-tools-VERSION-KERNELTYPE")
-                    _KERNEL_PKG_NAMES.append("linux-hwe-MAJOR_MINOR_VERSION-tools-VERSION")
-                    _KERNEL_PKG_NAMES.append("linux-hwe-MAJOR_MINOR_VERSION-headers-VERSION")
+                    _KERNEL_PKG_NAMES.extend([
+                        "linux-image-unsigned-VERSION-KERNELTYPE",
+                        "linux-tools-VERSION",
+                        "linux-tools-VERSION-KERNELTYPE",
+                        "linux-hwe-MAJOR_MINOR_VERSION-tools-VERSION",
+                        "linux-hwe-MAJOR_MINOR_VERSION-headers-VERSION",
+                    ])
 
                 for name in _KERNEL_PKG_NAMES:
                     name = (name


### PR DESCRIPTION
If you have the `linux-hwe-*-tools-*` or `linux-hwe-*-headers-*` kernel packages, remove these residual packages alongside the packages with the corresponding version.

It looks like there were no HWE `tools` and `headers` kernel packages before version `6.11.0` Ubuntu kernel. These residual packages are somewhat new in kernel packages.

- Fixes #1053
- Relates to #963

<details open>
<summary><b>Before & After screenshots</b></summary>

Before:
<img width="382" height="283" alt="01-linux-hwe-before" src="https://github.com/user-attachments/assets/f5685b4f-5e15-41d0-b342-fe70917aad7f" />

After:
<img width="401" height="395" alt="02-linux-hwe-after-highlighted" src="https://github.com/user-attachments/assets/ec3e0ac4-d646-4cd0-b315-86efa60e1bd6" />

</details>