### PR TITLE
Match the update's summary and description with its title

### DIFF
--- a/usr/lib/linuxmint/mintUpdate/Classes.py
+++ b/usr/lib/linuxmint/mintUpdate/Classes.py
@@ -173,7 +173,7 @@ class Update():
             if package.candidate.section == "kernel" or self.package_name.startswith("linux-headers") or self.real_source_name in ["linux", "linux-kernel", "linux-signed", "linux-meta"]:
                 self.type = "kernel"
 
-    def add_package(self, pkg):
+    def add_package(self, pkg, source_pkg = None):
         if self.main_package_name in SOURCE_PACKAGE_NAME_OVERRIDES:
             self.display_name = self.source_name
 
@@ -185,6 +185,12 @@ class Update():
             return
 
         if self.main_package_name != self.source_name:
+            # Use source package's information if exists
+            if (source_pkg is not None
+                    and self.type != "kernel"
+                    and pkg.name not in SOURCE_PACKAGE_NAME_OVERRIDES):
+                self.overwrite_main_package(source_pkg)
+                return
             # Overwrite dev, dbg, common, arch packages
             for suffix in ["-dev", "-dbg", "-common", "-core", "-data", "-doc", ":i386", ":amd64"]:
                 if (self.main_package_name.endswith(suffix) and not pkg.name.endswith(suffix)):

--- a/usr/lib/linuxmint/mintUpdate/aptUpdater.py
+++ b/usr/lib/linuxmint/mintUpdate/aptUpdater.py
@@ -406,7 +406,12 @@ class AptUpdater():
         if source_name in PRIORITY_UPDATES or not self.priority_updates_available:
             if source_name in self.updates:
                 update = self.updates[source_name]
-                update.add_package(package)
+
+                source_package = None
+                if update.main_package_name != source_name:
+                    source_package = self.cache.get(source_name)
+
+                update.add_package(package, source_package)
                 # Adjust update.old_version for kernel updates to try and
                 # match the kernel, not the meta
                 if kernel_update and package.is_installed and \


### PR DESCRIPTION
When multiple updatable packages are grouped together as an update, the group uses its `source` in APT description as its title in GUI.

The title can correspond to a package itself but not necessarily be updatable at that moment. In this case, the summary and description of the first package in the changelist are used whose name doesn't begin with `lib` and end with `dev`, `dbg`, `common`, `core`, `data` or `doc`.

This PR uses the source package's summary and description to match with the group's title if the source package exists. If a package doesn't exist with the title's name, the code shouldn't cause an error. (e.g., updatable package `libfprint-2-2`, its source `libfprint`: no package by that name.) 

This implementation doesn't feel ideal; I implemented it for minimal change in terms of lines, and I didn't want to introduce a circular dependency between `AptUpdater` (old `APTCheck`) and `Update` classes. I just wanted to explore the root cause of the issue, that's why it is kind of hacky.

- Closes #806


<details>
<summary><b>vim</b> specific explanation</summary>

```
$ apt-cache show vim-common | grep Source
Source: vim
```

but updatable changes doesn't include `vim`, so GUI uses first acceptable change for the summary and description: `xxd`.

updatable packages:
```
[
 <Package: name:'vim-gui-common' architecture='amd64' id:136982>,
 <Package: name:'xxd' architecture='amd64' id:10585>,
 <Package: name:'vim-gtk3' architecture='amd64' id:11795>,
 <Package: name:'vim-common' architecture='amd64' id:10066>,
 <Package: name:'vim-runtime' architecture='amd64' id:11791>
]
```
</details>

<details open >
<summary><b>vim before & after screenshots</b></summary>

Before:
<img width="515" height="384" alt="01-vim-summary-desc-before" src="https://github.com/user-attachments/assets/951dc64c-4060-4c03-94af-be3aa580ce66" />


After:
<img width="515" height="432" alt="02-vim-summary-desc-after" src="https://github.com/user-attachments/assets/e8f78c36-268a-4eca-b74b-b9023bacc55d" />
</details>